### PR TITLE
Setting sentinel values to gate coupling mappings

### DIFF
--- a/include/qdmi_internal.h
+++ b/include/qdmi_internal.h
@@ -130,6 +130,8 @@ typedef struct QDMI_Gate_impl_d
     QDMI_Gate_property** coupling_mapping;
     char *unitary;
     float fidelity;
+    size_t size_coupling_map;
+    size_t gate_size;
 } QDMI_Gate_impl_t;
 
 typedef struct QDMI_Qubit_impl_d

--- a/src/qdmi_backend_ibm.c
+++ b/src/qdmi_backend_ibm.c
@@ -278,43 +278,60 @@ void QDMI_get_gate_info(QDMI_Device dev, int gate_index, QDMI_Gate gate)
         //fprintf(stderr, "Error: 'coupling_map' is not an array.\n");
     }
     size_t num_coupling_maps = json_array_size(coupling_map_array);
-    // Allocate memory for coupling maps
-    gate->coupling_mapping = (QDMI_Gate_property **)malloc(num_coupling_maps * sizeof(QDMI_Gate_property *));
-    if (!gate->coupling_mapping) {
-        fprintf(stderr, "Error: Memory allocation failed.\n");
-    }
-    size_t num_connections;
-    // Loop through each coupling map
-    for (size_t j = 0; j < num_coupling_maps; ++j) {
-        json_t *coupling_map = json_array_get(coupling_map_array, j);
-        if (!json_is_array(coupling_map)) {
-            fprintf(stderr, "Error: Invalid coupling map.\n");
-            continue;
-        }
-        num_connections = json_array_size(coupling_map);
-        // Allocate memory for current coupling map
-        gate->coupling_mapping[j] = (int *)malloc(num_connections * sizeof(int));
-        if (!gate->coupling_mapping[j]) {
+    
+    if(num_coupling_maps != 0){
+        // Allocate memory for coupling maps
+        // Notice (num_coupling_maps + 1) -> To store a sentinel value so that FoMac knows when to stop looking for indices
+        gate->coupling_mapping = (QDMI_Gate_property **)malloc((num_coupling_maps + 1) * sizeof(QDMI_Gate_property *));
+        if (!gate->coupling_mapping) {
             fprintf(stderr, "Error: Memory allocation failed.\n");
-            // Free previously allocated memory
-            for (size_t k = 0; k < j; ++k) {
-                free(gate->coupling_mapping[k]);
-            }
-            free(gate->coupling_mapping);
-            continue;
         }
-        // Loop through each connection in the coupling map
-        for (size_t k = 0; k < num_connections; ++k) {
-            json_t *connection = json_array_get(coupling_map, k);
-            if (!json_is_integer(connection)) {
-                fprintf(stderr, "Error: Invalid connection.\n");
+        size_t num_connections;
+        // Loop through each coupling map
+        for (size_t j = 0; j < num_coupling_maps; ++j) {
+            json_t *coupling_map = json_array_get(coupling_map_array, j);
+            if (!json_is_array(coupling_map)) {
+                fprintf(stderr, "Error: Invalid coupling map.\n");
                 continue;
             }
-            int qubit = json_integer_value(connection);
-            gate->coupling_mapping[j][k] = qubit;
+            num_connections = json_array_size(coupling_map);
+
+            // Allocate memory for current coupling map
+            // Notice (num_connections + 1) -> To store a sentinel value so that FoMac knows when to stop looking for indices
+            gate->coupling_mapping[j] = (int *)malloc((num_connections + 1)* sizeof(int));
+            if (!gate->coupling_mapping[j]) {
+                fprintf(stderr, "Error: Memory allocation failed.\n");
+                // Free previously allocated memory
+                for (size_t k = 0; k < j; ++k) {
+                    free(gate->coupling_mapping[k]);
+                }
+                free(gate->coupling_mapping);
+                continue;
+            }
+            // Loop through each connection in the coupling map
+            for (size_t k = 0; k < num_connections; ++k) {
+                json_t *connection = json_array_get(coupling_map, k);
+                if (!json_is_integer(connection)) {
+                    fprintf(stderr, "Error: Invalid connection.\n");
+                    continue;
+                }
+                int qubit = json_integer_value(connection);
+                gate->coupling_mapping[j][k] = qubit; 
+
+                // Set sentinel value = -1
+                if(k == num_connections-1) gate->coupling_mapping[j][k+1] = -1;
+            }
+
+            // Set sentinel value to NULL
+            if(j == num_coupling_maps-1) gate->coupling_mapping[j+1] = NULL;
         }
     }
-    
+    // Set coupling_mapping to NULL if the backend doesn't provide it
+    else {
+        gate->coupling_mapping = NULL;
+    }   
+    gate->unitary  = "Unitary_Matrix";
+    gate->fidelity = 1.0;
 }
 
 int QDMI_query_all_gates(QDMI_Device dev, QDMI_Gate *gates)


### PR DESCRIPTION
Some quantum backends provide coupling maps for gates as well. The coupling maps provide a list of qubits that the gate applies to, where each element of the list is an n-qubit list where n is the size of the gate (e.g. 1-qubit gate, 2-qubit gate). For example, the coupling map for a CX gate on a 5-qubit backend could be: [[0, 1], [1, 0],[1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3]]. 

`struct QDMI_Gate_impl_d` has a `coupling_mapping` member: https://github.com/Munich-Quantum-Software-Stack/QDMI/blob/ea3c65888cae9ee995a477e787333d535bbe2eb5/include/qdmi_internal.h#L130

If the backend doesn't provide a `coupling_mapping` for a particular gate, this must be set to NULL. If it does, this member stores the corresponding mapping as an int** (int [][]) as a typedef `QDMI_Gate_property`. However, this raw pointer doesn't store any information regarding the size of the coupling mapping. Also, there's no member in the `QDMI_Gate_impl_d` struct, which stores the gate size (1-qubit, 2-qubit, etc.). When a C++-based higher-level library like FoMac or `sys-sage` tries to access this information, it'll be convenient to provide it.

This PR presents one of the possible solutions: setting sentinel values at the end of the pointers pointed to by the coupling_mapping. 

If the size of `gate->coupling_mapping` is N, memory for N+1 pointers to QDMI_Gate_property could be allocated to store an extra NULL value. Similarly, for every `gate->coupling_mapping[i]`, where i = 0,1...N-1, i+N can store the value -1 (as qubit indices can never be negative). This will help higher-level libraries to get the count of the qubits involved and the size of the coupling mapping. 

The reference solution is implemented for the IBM backend