### PR TITLE
Implementing device property query for char

### DIFF
--- a/include/qdmi.h
+++ b/include/qdmi.h
@@ -114,7 +114,6 @@ typedef int QDMI_Gate_property;
 // typedef int QDMI_Qubit_property;
 
 typedef int QDMI_Device_property;
-//typedef struct QDMI_Device_property_impl_d *QDMI_Device_property;
 typedef struct QDMI_Qubit_property_impl_d *QDMI_Qubit_property;
 typedef struct QDMI_Gate_impl_d            *QDMI_Gate;
 typedef struct QDMI_Unitary_impl_d         *QDMI_Unitary;
@@ -209,7 +208,7 @@ typedef int (*QDMI_query_device_property_exists_t)(QDMI_Device dev, QDMI_Device_
 int QDMI_query_device_property_type(QDMI_Device dev, QDMI_Device_property prop);
 typedef int (*QDMI_query_device_property_type_t)(QDMI_Device dev, QDMI_Device_property prop);
 
-// query device property as int or float
+// query device property as int, char, float, double
 int QDMI_query_device_property_i(QDMI_Device dev, QDMI_Device_property prop, int *value);
 typedef int (*QDMI_query_device_property_i_t)(QDMI_Device dev, QDMI_Device_property prop, int *value);
 int QDMI_query_device_property_c(QDMI_Device dev, QDMI_Device_property prop, char **value);

--- a/include/qdmi.h
+++ b/include/qdmi.h
@@ -113,8 +113,8 @@ typedef int QDMI_qubit_index;
 typedef int QDMI_Gate_property;
 // typedef int QDMI_Qubit_property;
 
-//typedef int QDMI_Device_property;
-typedef struct QDMI_Device_property_impl_d *QDMI_Device_property;
+typedef int QDMI_Device_property;
+//typedef struct QDMI_Device_property_impl_d *QDMI_Device_property;
 typedef struct QDMI_Qubit_property_impl_d *QDMI_Qubit_property;
 typedef struct QDMI_Gate_impl_d            *QDMI_Gate;
 typedef struct QDMI_Unitary_impl_d         *QDMI_Unitary;
@@ -212,6 +212,8 @@ typedef int (*QDMI_query_device_property_type_t)(QDMI_Device dev, QDMI_Device_pr
 // query device property as int or float
 int QDMI_query_device_property_i(QDMI_Device dev, QDMI_Device_property prop, int *value);
 typedef int (*QDMI_query_device_property_i_t)(QDMI_Device dev, QDMI_Device_property prop, int *value);
+int QDMI_query_device_property_c(QDMI_Device dev, QDMI_Device_property prop, char **value);
+typedef int (*QDMI_query_device_property_c_t)(QDMI_Device dev, QDMI_Device_property prop, char **value);
 int QDMI_query_device_property_f(QDMI_Device dev, QDMI_Device_property prop, float *value);
 typedef int (*QDMI_query_device_property_f_t)(QDMI_Device dev, QDMI_Device_property prop, float *value);
 int QDMI_query_device_property_d(QDMI_Device dev, QDMI_Device_property prop, double *value);

--- a/src/private/qdmi_internal.h
+++ b/src/private/qdmi_internal.h
@@ -70,6 +70,7 @@ typedef struct QDMI_Library_impl_d
     QDMI_control_readout_raw_sample_t   QDMI_control_readout_raw_sample;
     QDMI_query_device_property_exists_t QDMI_query_device_property_exists;
     QDMI_query_device_property_type_t   QDMI_query_device_property_type;
+    QDMI_query_device_property_c_t      QDMI_query_device_property_c;
     QDMI_query_device_property_i_t      QDMI_query_device_property_i;
     QDMI_query_device_property_f_t      QDMI_query_device_property_f;
     QDMI_query_device_property_d_t      QDMI_query_device_property_d;

--- a/src/private/qdmi_internal.h
+++ b/src/private/qdmi_internal.h
@@ -132,12 +132,6 @@ typedef struct QDMI_Device_impl_d
     void                   *device_state;
 } QDMI_Device_impl_t;
 
-typedef struct QDMI_Device_property_impl_d
-{
-    int name;  // for e.g. 15 for backend_name
-    int type;  //INT_PROPERTY, etc,
-} QDMI_Device_property_impl_t;
-
 typedef struct QDMI_Qubit_property_impl_d
 {
     int name;  // for e.g. 15 for backend_name

--- a/src/qdmi_stubs.c
+++ b/src/qdmi_stubs.c
@@ -92,6 +92,11 @@ int QDMI_query_device_property_type(QDMI_Device dev, QDMI_Device_property prop)
     return dev->library.QDMI_query_device_property_type(dev, prop);
 }
 
+int QDMI_query_device_property_c(QDMI_Device dev, QDMI_Device_property prop, char **value)
+{
+    return dev->library.QDMI_query_device_property_c(dev, prop, value);
+}
+
 int QDMI_query_device_property_i(QDMI_Device dev, QDMI_Device_property prop, int *value)
 {
     return dev->library.QDMI_query_device_property_i(dev, prop, value);


### PR DESCRIPTION
I implemented QDMI_query_device_property_c to get backend information as a string. QDMI_Device_property was defined as a struct, and I changed it back to int.  

FYI @echavarria-lrz @Durganshu 