### PR TITLE
🔧 always build QDMI as a shared library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 if(NOT TARGET qdmi)
   add_library(
-    qdmi
+    qdmi SHARED
     ${QDMI_INCLUDE_BUILD_DIR}/qdmi.h ${QDMI_INCLUDE_BUILD_DIR}/qdmi_backend.h
     qdmi_core.c qdmi_internal.c qdmi_stubs.c)
 


### PR DESCRIPTION
Based on the discussion in https://github.com/Munich-Quantum-Software-Stack/QDMI/discussions/48 there are problems when building QDMI as a static library.
Thus, this PR changes the library to always building as a dynamic library.