### PR TITLE
QDMI_Job is included in readout routines.

### DIFF
--- a/include/qdmi/qdmi.h
+++ b/include/qdmi/qdmi.h
@@ -184,27 +184,27 @@ typedef int (*QDMI_control_extract_state_t)(QDMI_Device dev, QDMI_Status status,
 
 /* read out routines */
 
-int QDMI_control_readout_size(QDMI_Device dev, QDMI_Status *status, QDMI_Job *job,
+int QDMI_control_readout_size(QDMI_Device dev, QDMI_Status *status, QDMI_Job job,
                               int *numbits);
-typedef int (*QDMI_control_readout_size_t)(QDMI_Device dev, QDMI_Status *status, QDMI_Job *job,
+typedef int (*QDMI_control_readout_size_t)(QDMI_Device dev, QDMI_Status *status, QDMI_Job job,
                                            int *numbits);
 
 /* Histogram */
-int QDMI_control_readout_hist_size(QDMI_Device dev, QDMI_Status *status, QDMI_Job *job,
+int QDMI_control_readout_hist_size(QDMI_Device dev, QDMI_Status *status, QDMI_Job job,
                                    int *size);
 typedef int (*QDMI_control_readout_hist_size_t)(QDMI_Device dev,QDMI_Status *status, 
-                                  QDMI_Job *job, int *size);
-int QDMI_control_readout_hist_top(QDMI_Device dev, QDMI_Status *status, QDMI_Job *job,
+                                  QDMI_Job job, int *size);
+int QDMI_control_readout_hist_top(QDMI_Device dev, QDMI_Status *status, QDMI_Job job,
                                   int numhist, QInfo info, long *hist);
 typedef int (*QDMI_control_readout_hist_top_t)(QDMI_Device dev,
-                                               QDMI_Status *status, QDMI_Job *job, int numhist,
+                                               QDMI_Status *status, QDMI_Job job, int numhist,
                                                QInfo info, long *hist);
 
 /* Full data */
 int QDMI_control_readout_raw_num(QDMI_Device dev, QDMI_Status *status, 
-                                QDMI_Job *job, int *num);
+                                QDMI_Job job, int *num);
 typedef int (*QDMI_control_readout_raw_num_t)(QDMI_Device dev,
-                                              QDMI_Status *status, QDMI_Job *job,
+                                              QDMI_Status *status, QDMI_Job job,
                                               int *num);
 int QDMI_control_readout_raw_sample(QDMI_Device dev, QDMI_Status *status,
                                     int numraw, QInfo info, long *hist);

--- a/src/qdmi_stubs.c
+++ b/src/qdmi_stubs.c
@@ -48,24 +48,24 @@ int QDMI_control_extract_state(QDMI_Device dev, QDMI_Status status,
   return dev->library.QDMI_control_extract_state(dev, status, state);
 }
 
-int QDMI_control_readout_size(QDMI_Device dev, QDMI_Status *status, QDMI_Job *job,
+int QDMI_control_readout_size(QDMI_Device dev, QDMI_Status *status, QDMI_Job job,
                               int *numbits) {
   return dev->library.QDMI_control_readout_size(dev, status, job, numbits);
 }
 
-int QDMI_control_readout_hist_size(QDMI_Device dev, QDMI_Status *status, QDMI_Job *job,
+int QDMI_control_readout_hist_size(QDMI_Device dev, QDMI_Status *status, QDMI_Job job,
                                    int *size) {
   return dev->library.QDMI_control_readout_hist_size(dev, status, job, size);
 }
 
-int QDMI_control_readout_hist_top(QDMI_Device dev, QDMI_Status *status, QDMI_Job *job,
+int QDMI_control_readout_hist_top(QDMI_Device dev, QDMI_Status *status, QDMI_Job job,
                                   int numhist, QInfo info, long *hist) {
   return dev->library.QDMI_control_readout_hist_top(dev, status, job, numhist, info,
                                                     hist);
 }
 
 int QDMI_control_readout_raw_num(QDMI_Device dev, QDMI_Status *status,
-                                 QDMI_Job *job, int *num) {
+                                 QDMI_Job job, int *num) {
   return dev->library.QDMI_control_readout_raw_num(dev, status, job, num);
 }
 


### PR DESCRIPTION
The task_id needs to be created by backend. Therefore, QDMI_Job must be included in readout routines. Please see #39 .