### PR TITLE
✏️  remove redundant abbreviation in readme header

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![QDMI](docs/_static/qdmi.png)
 
-# QDMI — Quantum Device Management Interface (QDMI)
+# QDMI — Quantum Device Management Interface
 
 <p align="center">
   <a href="https://munich-quantum-software-stack.github.io/QDMI/">


### PR DESCRIPTION
Just a quick fix that removes the redundant header abbreviation for QDMI