### PR TITLE
🚨 Fix shadowing of global devices list in qdmi_example_driver.cpp

### DIFF
--- a/examples/driver/qdmi_example_driver.cpp
+++ b/examples/driver/qdmi_example_driver.cpp
@@ -106,7 +106,7 @@ struct QDMI_Session_impl_d {
 /**
  * @brief Global list of devices managed by the driver.
  */
-std::vector<std::shared_ptr<QDMI_Device_impl_d>> devices;
+std::vector<std::shared_ptr<QDMI_Device_impl_d>> device_list;
 
 #define LOAD_SYMBOL(device, symbol)                                            \
   {                                                                            \
@@ -197,7 +197,7 @@ int QDMI_Driver_init() {
     }
 
     try {
-      devices.emplace_back(QDMI_Device_open(lib_name, mode));
+      device_list.emplace_back(QDMI_Device_open(lib_name, mode));
     } catch (const std::exception &e) {
       std::cerr << "Failed to open device: " << e.what() << "\n";
       return QDMI_ERROR_FATAL;
@@ -211,7 +211,7 @@ int QDMI_Driver_init() {
 int QDMI_session_alloc(QDMI_Session *session) {
   *session = new QDMI_Session_impl_d();
   // in this simple implementation, each session has access to all devices
-  (*session)->device_list = devices;
+  (*session)->device_list = device_list;
   return QDMI_SUCCESS;
 }
 
@@ -252,7 +252,7 @@ void QDMI_session_free(QDMI_Session session) { delete session; }
 
 int QDMI_Driver_shutdown() {
   // Close all devices
-  devices.clear();
+  device_list.clear();
   return QDMI_SUCCESS;
 }
 

--- a/examples/driver/qdmi_example_driver.cpp
+++ b/examples/driver/qdmi_example_driver.cpp
@@ -103,9 +103,11 @@ struct QDMI_Session_impl_d {
  * @{
  */
 
+namespace {
 /**
  * @brief Global list of devices managed by the driver.
  */
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::vector<std::shared_ptr<QDMI_Device_impl_d>> device_list;
 
 #define LOAD_SYMBOL(device, symbol)                                            \
@@ -159,6 +161,7 @@ QDMI_Device_open(const std::string &lib_name, const QDMI_Device_Mode mode) {
 
   return device_handle;
 }
+} // namespace
 
 int QDMI_Driver_init() {
   const char *config_file = std::getenv("QDMI_CONF");
@@ -273,13 +276,13 @@ int QDMI_query_get_operations(const QDMI_Device device, const int num_entries,
 }
 
 int QDMI_query_device_property(const QDMI_Device device,
-                               const QDMI_Device_Property prop, const int size,
+                               QDMI_Device_Property prop, const int size,
                                void *value, int *size_ret) {
   return device->query_device_property(prop, size, value, size_ret);
 }
 
 int QDMI_query_site_property(const QDMI_Device device, const QDMI_Site site,
-                             const QDMI_Site_Property prop, const int size,
+                             QDMI_Site_Property prop, const int size,
                              void *value, int *size_ret) {
   return device->query_site_property(site, prop, size, value, size_ret);
 }
@@ -287,14 +290,14 @@ int QDMI_query_site_property(const QDMI_Device device, const QDMI_Site site,
 int QDMI_query_operation_property(const QDMI_Device device,
                                   const QDMI_Operation operation,
                                   const int num_sites, const QDMI_Site *sites,
-                                  const QDMI_Operation_Property prop,
-                                  const int size, void *value, int *size_ret) {
+                                  QDMI_Operation_Property prop, const int size,
+                                  void *value, int *size_ret) {
   return device->query_operation_property(operation, num_sites, sites, prop,
                                           size, value, size_ret);
 }
 
 int QDMI_control_create_job(QDMI_Device dev, QDMI_Program_Format format,
-                            int size, const void *prog, QDMI_Job *job) {
+                            const int size, const void *prog, QDMI_Job *job) {
   if ((dev->mode & QDMI_DEVICE_MODE_READWRITE) != 0) {
     return dev->control_create_job(format, size, prog, job);
   }
@@ -302,7 +305,7 @@ int QDMI_control_create_job(QDMI_Device dev, QDMI_Program_Format format,
 }
 
 int QDMI_control_set_parameter(QDMI_Device dev, QDMI_Job job,
-                               QDMI_Job_Parameter param, int size,
+                               QDMI_Job_Parameter param, const int size,
                                const void *value) {
   if ((dev->mode & QDMI_DEVICE_MODE_READWRITE) != 0) {
     return dev->control_set_parameter(job, param, size, value);
@@ -339,7 +342,7 @@ int QDMI_control_wait(QDMI_Device dev, QDMI_Job job) {
 }
 
 int QDMI_control_get_data(QDMI_Device dev, QDMI_Job job, QDMI_Job_Result result,
-                          int size, void *data, int *size_ret) {
+                          const int size, void *data, int *size_ret) {
   if ((dev->mode & QDMI_DEVICE_MODE_READWRITE) != 0) {
     return dev->control_get_data(job, result, size, data, size_ret);
   }

--- a/examples/driver/qdmi_example_driver.cpp
+++ b/examples/driver/qdmi_example_driver.cpp
@@ -265,30 +265,28 @@ int QDMI_Driver_shutdown() {
  * @{
  */
 
-int QDMI_query_get_sites(const QDMI_Device device, const int num_entries,
+int QDMI_query_get_sites(QDMI_Device device, const int num_entries,
                          QDMI_Site *sites, int *num_sites_ret) {
   return device->query_get_sites(num_entries, sites, num_sites_ret);
 }
 
-int QDMI_query_get_operations(const QDMI_Device device, const int num_entries,
+int QDMI_query_get_operations(QDMI_Device device, const int num_entries,
                               QDMI_Operation *operations, int *num_operations) {
   return device->query_get_operations(num_entries, operations, num_operations);
 }
 
-int QDMI_query_device_property(const QDMI_Device device,
-                               QDMI_Device_Property prop, const int size,
-                               void *value, int *size_ret) {
+int QDMI_query_device_property(QDMI_Device device, QDMI_Device_Property prop,
+                               const int size, void *value, int *size_ret) {
   return device->query_device_property(prop, size, value, size_ret);
 }
 
-int QDMI_query_site_property(const QDMI_Device device, const QDMI_Site site,
+int QDMI_query_site_property(QDMI_Device device, QDMI_Site site,
                              QDMI_Site_Property prop, const int size,
                              void *value, int *size_ret) {
   return device->query_site_property(site, prop, size, value, size_ret);
 }
 
-int QDMI_query_operation_property(const QDMI_Device device,
-                                  const QDMI_Operation operation,
+int QDMI_query_operation_property(QDMI_Device device, QDMI_Operation operation,
                                   const int num_sites, const QDMI_Site *sites,
                                   QDMI_Operation_Property prop, const int size,
                                   void *value, int *size_ret) {


### PR DESCRIPTION
Fixes #74

Rename the global `devices` list to `device_list` in `examples/driver/qdmi_example_driver.cpp`.

* Update the global `devices` list definition at line 109 to `device_list`.
* Update all references to the global `devices` list to use the new name `device_list`.
* Ensure the `devices` parameter in the method at line 219 no longer shadows the global `devices` list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Munich-Quantum-Software-Stack/QDMI/issues/74?shareId=0a9d356c-9ce8-4651-9e2f-0160fc3aa8d7).