### PR TITLE
⚡ enable compiler cache if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ project(
 # make scripts available to cmake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+include(cmake/Cache.cmake)
+
 # check if this is the master project or used via add_subdirectory
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   set(QDMI_MASTER_PROJECT ON)

--- a/cmake/Cache.cmake
+++ b/cmake/Cache.cmake
@@ -1,0 +1,26 @@
+option(ENABLE_CACHE "Enable compiler cache if available" ON)
+if(NOT ENABLE_CACHE)
+  return()
+endif()
+
+set(CACHE_OPTION_VALUES "ccache" "sccache")
+set(CACHE_OPTION
+    "ccache"
+    CACHE STRING "Compiler cache to use")
+set_property(CACHE CACHE_OPTION PROPERTY STRINGS ${CACHE_OPTION_VALUES})
+list(FIND CACHE_OPTION_VALUES ${CACHE_OPTION} CACHE_OPTION_INDEX)
+if(CACHE_OPTION_INDEX EQUAL -1)
+  message(
+    NOTICE
+    "Unknown compiler cache '${CACHE_OPTION}'. Available options are: ${CACHE_OPTION_VALUES}"
+  )
+endif()
+
+find_program(CACHE_BINARY ${CACHE_OPTION})
+if(CACHE_BINARY)
+  message(STATUS "Compiler cache '${CACHE_OPTION}' found and enabled")
+  set(CMAKE_C_COMPILER_LAUNCHER ${CACHE_BINARY})
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CACHE_BINARY})
+else()
+  message(NOTICE "${CACHE_OPTION} is enabled but was not found. Not using it")
+endif()


### PR DESCRIPTION
This PR adds a small CMake helper that enables the compiler cache for faster builds, if it is available.
It is made available in all CI workflows by default.