### PR TITLE
✨ Add Readout Format for State Vector and Probabilities

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -34,11 +34,15 @@ QDMI_query_device_property_dev function. Below you find the respective implement
   \skip QDMI_query_device_property_dev
   \until QDMI_DEVICE_PROPERTY_LIBRARYVERSION
   \until size_ret)
+  \skip QDMI_ERROR_NOTSUPPORTED
+  \until DOXYGEN FUNCTION END
 - <b class="tab-title">C++</b>
   \dontinclude device.cpp
   \skip QDMI_query_device_property_dev
   \until QDMI_DEVICE_PROPERTY_LIBRARYVERSION
   \until size_ret)
+  \skip QDMI_ERROR_NOTSUPPORTED
+  \until DOXYGEN FUNCTION END
 </div>
 <!-- prettier-ignore-end -->
 
@@ -55,15 +59,11 @@ implementation of the @ref QDMI_query_device_property_dev function.
 - <b class="tab-title">C</b>
   \dontinclude device.c
   \skip #define ADD_STRING_PROPERTY
-  \until return QDMI_SUCCESS;
-  \until }
-  \until }
+  \until DOXYGEN MACRO END
 - <b class="tab-title">C++</b>
   \dontinclude device.cpp
   \skip #define ADD_STRING_PROPERTY
-  \until return QDMI_SUCCESS;
-  \until }
-  \until }
+  \until DOXYGEN MACRO END
 </div>
 <!-- prettier-ignore-end -->
 
@@ -74,15 +74,11 @@ A similar macro is defined for other (fixed length) data types, e.g., `int`, `do
 - <b class="tab-title">C</b>
   \dontinclude device.c
   \skip #define ADD_SINGLE_VALUE_PROPERTY
-  \until return QDMI_SUCCESS;
-  \until }
-  \until }
+  \until DOXYGEN MACRO END
 - <b class="tab-title">C++</b>
   \dontinclude device.cpp
   \skip #define ADD_SINGLE_VALUE_PROPERTY
-  \until return QDMI_SUCCESS;
-  \until }
-  \until }
+  \until DOXYGEN MACRO END
 </div>
 <!-- prettier-ignore-end -->
 
@@ -93,15 +89,11 @@ Another macro is defined for list properties of the data types above.
 - <b class="tab-title">C</b>
   \dontinclude device.c
   \skip #define ADD_LIST_PROPERTY
-  \until return QDMI_SUCCESS;
-  \until }
-  \until }
+  \until DOXYGEN MACRO END
 - <b class="tab-title">C++</b>
   \dontinclude device.cpp
   \skip #define ADD_LIST_PROPERTY
-  \until return QDMI_SUCCESS;
-  \until }
-  \until }
+  \until DOXYGEN MACRO END
 </div>
 <!-- prettier-ignore-end -->
 
@@ -121,6 +113,8 @@ device.
   \skip QDMI_DEVICE_PROPERTY_QUBITSNUM
   \until QDMI_DEVICE_PROPERTY_STATUS
   \until size_ret)
+  \skip QDMI_ERROR_NOTSUPPORTED
+  \until DOXYGEN FUNCTION END
 - <b class="tab-title">C++</b>
   \dontinclude device.cpp
   \skip QDMI_query_device_property_dev
@@ -128,6 +122,8 @@ device.
   \skip QDMI_DEVICE_PROPERTY_QUBITSNUM
   \until QDMI_DEVICE_PROPERTY_STATUS
   \until size_ret)
+  \skip QDMI_ERROR_NOTSUPPORTED
+  \until DOXYGEN FUNCTION END
 </div>
 <!-- prettier-ignore-end -->
 
@@ -144,7 +140,7 @@ flattened into a single list of @ref QDMI_Site's.
   \skip QDMI_query_device_property_dev
   \until {
   \skip ADD_LIST_PROPERTY
-  \until size_ret)
+  \until DOXYGEN FUNCTION END
 - <b class="tab-title">C++</b>
   \dontinclude device.cpp
   \skipline constexpr static std::array<const QDMI_Site_impl_d *const, 20>
@@ -152,8 +148,8 @@ flattened into a single list of @ref QDMI_Site's.
   \until ;
   \skip QDMI_query_device_property_dev
   \until {
-  \skip QDMI_DEVICE_PROPERTY_COUPLINGMAP
-  \until size_ret)
+  \skip ADD_LIST_PROPERTY
+  \until DOXYGEN FUNCTION END
 </div>
 <!-- prettier-ignore-end -->
 

--- a/examples/device/c/device.c
+++ b/examples/device/c/device.c
@@ -86,7 +86,7 @@ const QDMI_Operation DEVICE_OPERATIONS[] = {
       }                                                                        \
       return QDMI_SUCCESS;                                                     \
     }                                                                          \
-  }
+  } /// [DOXYGEN MACRO END]
 
 #define ADD_STRING_PROPERTY(prop_name, prop_value, prop, size, value,          \
                             size_ret)                                          \
@@ -104,7 +104,7 @@ const QDMI_Operation DEVICE_OPERATIONS[] = {
       }                                                                        \
       return QDMI_SUCCESS;                                                     \
     }                                                                          \
-  }
+  } /// [DOXYGEN MACRO END]
 
 #define ADD_LIST_PROPERTY(prop_name, prop_type, prop_values, prop_length,      \
                           prop, size, value, size_ret)                         \
@@ -122,7 +122,7 @@ const QDMI_Operation DEVICE_OPERATIONS[] = {
       }                                                                        \
       return QDMI_SUCCESS;                                                     \
     }                                                                          \
-  }
+  } /// [DOXYGEN MACRO END]
 
 int QDMI_query_get_sites_dev(const size_t num_entries, QDMI_Site *sites,
                              size_t *num_sites) {

--- a/examples/device/c/device.c
+++ b/examples/device/c/device.c
@@ -520,10 +520,11 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
       result == QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES) {
     const size_t length = job->state_vec_length / 2;
     const size_t num_qubits = (size_t)log2((double)length);
+    const double *vec = job->state_vec;
     // count non-zero elements
     size_t count = 0;
     for (size_t i = 0; i < length; ++i) {
-      if (job->state_vec[2 * i] != 0.0 || job->state_vec[(2 * i) + 1] != 0.0) {
+      if (vec[2 * i] != 0.0 || vec[(2 * i) + 1] != 0.0) {
         count++;
       }
     }
@@ -536,8 +537,7 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
         }
         char *data_ptr = data;
         for (size_t i = 0; i < length; ++i) {
-          if (job->state_vec[2 * i] != 0.0 ||
-              job->state_vec[(2 * i) + 1] != 0.0) {
+          if (vec[2 * i] != 0.0 || vec[(2 * i) + 1] != 0.0) {
             for (size_t j = 0; j < num_qubits; j++) {
               *data_ptr++ = (i & (1ULL << (num_qubits - j - 1))) ? '1' : '0';
             }
@@ -559,10 +559,9 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
         }
         double *data_ptr = data;
         for (size_t i = 0; i < length; ++i) {
-          if (job->state_vec[2 * i] != 0.0 ||
-              job->state_vec[(2 * i) + 1] != 0.0) {
-            *data_ptr++ = job->state_vec[2 * i];
-            *data_ptr++ = job->state_vec[(2 * i) + 1];
+          if (vec[2 * i] != 0.0 || vec[(2 * i) + 1] != 0.0) {
+            *data_ptr++ = vec[2 * i];
+            *data_ptr++ = vec[(2 * i) + 1];
           }
         }
       }
@@ -577,11 +576,9 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
         }
         double *data_ptr = data;
         for (size_t i = 0; i < length; ++i) {
-          if (job->state_vec[2 * i] != 0.0 ||
-              job->state_vec[(2 * i) + 1] != 0.0) {
-            *data_ptr++ =
-                (job->state_vec[2 * i] * job->state_vec[2 * i]) +
-                (job->state_vec[(2 * i) + 1] * job->state_vec[(2 * i) + 1]);
+          if (vec[2 * i] != 0.0 || vec[(2 * i) + 1] != 0.0) {
+            *data_ptr++ = (vec[2 * i] * vec[2 * i]) +
+                          (vec[(2 * i) + 1] * vec[(2 * i) + 1]);
           }
         }
       }

--- a/examples/device/cxx/device.cpp
+++ b/examples/device/cxx/device.cpp
@@ -515,7 +515,7 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
     size_t count = 0;
     for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
       if (dense_data[2 * i] != 0.0 || dense_data[(2 * i) + 1] != 0.0) {
-        count++;
+        ++count;
       }
     }
     if (data != nullptr) {
@@ -553,7 +553,7 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
     size_t count = 0;
     for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
       if (dense_data[2 * i] != 0.0 || dense_data[(2 * i) + 1] != 0.0) {
-        count++;
+        ++count;
       }
     }
     if (data != nullptr) {
@@ -602,7 +602,7 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
     size_t count = 0;
     for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
       if (dense_data[i] != 0.0) {
-        count++;
+        ++count;
       }
     }
     if (data != nullptr) {
@@ -612,7 +612,7 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
       auto *data_ptr = static_cast<char *>(data);
       for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
         if (dense_data[i] != 0.0) {
-          for (size_t j = 0; j < num_qubits; j++) {
+          for (size_t j = 0; j < num_qubits; ++j) {
             *data_ptr++ = ((i & (1 << (num_qubits - j - 1))) != 0U) ? '1' : '0';
           }
           *data_ptr++ = ',';
@@ -640,7 +640,7 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
     size_t count = 0;
     for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
       if (dense_data[i] != 0.0) {
-        count++;
+        ++count;
       }
     }
     if (data != nullptr) {

--- a/examples/device/cxx/device.cpp
+++ b/examples/device/cxx/device.cpp
@@ -136,7 +136,7 @@ const static std::unordered_map<
       }                                                                        \
       return QDMI_SUCCESS;                                                     \
     }                                                                          \
-  }
+  } /// [DOXYGEN MACRO END]
 
 #define ADD_STRING_PROPERTY(prop_name, prop_value, prop, size, value,          \
                             size_ret)                                          \
@@ -154,7 +154,7 @@ const static std::unordered_map<
       }                                                                        \
       return QDMI_SUCCESS;                                                     \
     }                                                                          \
-  }
+  } /// [DOXYGEN MACRO END]
 
 #define ADD_LIST_PROPERTY(prop_name, prop_type, prop_values, prop, size,       \
                           value, size_ret)                                     \
@@ -173,7 +173,7 @@ const static std::unordered_map<
       }                                                                        \
       return QDMI_SUCCESS;                                                     \
     }                                                                          \
-  }
+  } /// [DOXYGEN MACRO END]
 // NOLINTEND(bugprone-macro-parentheses)
 
 int QDMI_query_get_sites_dev(const size_t num_entries, QDMI_Site *sites,

--- a/examples/device/cxx/device.cpp
+++ b/examples/device/cxx/device.cpp
@@ -14,12 +14,14 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <algorithm>
 #include <array>
+#include <cmath>
+#include <complex>
 #include <cstring>
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <map>
 #include <random>
-#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -30,6 +32,7 @@ struct QDMI_Job_impl_d {
   QDMI_Job_Status status = QDMI_JOB_STATUS_SUBMITTED;
   size_t num_shots = 0;
   std::vector<std::string> results;
+  std::vector<std::complex<double>> state_vec;
   std::bernoulli_distribution binary_dist{0.5};
 };
 
@@ -47,6 +50,8 @@ struct QDMI_Device_State {
   std::mt19937 gen{rd()};
   std::uniform_int_distribution<> dis =
       std::uniform_int_distribution<>(0, std::numeric_limits<int>::max());
+  std::uniform_real_distribution<> dis_real =
+      std::uniform_real_distribution<>(-1.0, 1.0);
 };
 
 namespace {
@@ -357,6 +362,21 @@ int QDMI_control_submit_job_dev(QDMI_Job job) {
     });
     job->results.emplace_back(std::move(result));
   }
+  // Generate random complex numbers and calculate the norm
+  job->state_vec.clear();
+  job->state_vec.reserve(1U << num_qubits);
+  double norm = 0.0;
+  for (size_t i = 0; i < 1U << num_qubits; ++i) {
+    const auto &c =
+        job->state_vec.emplace_back(device_state.dis_real(device_state.gen),
+                                    device_state.dis_real(device_state.gen));
+    norm += std::norm(c);
+  }
+  // Normalize the vector
+  norm = std::sqrt(norm);
+  for (auto &c : job->state_vec) {
+    c /= norm;
+  }
   return QDMI_SUCCESS;
 } /// [DOXYGEN FUNCTION END]
 
@@ -416,72 +436,226 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
     }
     return QDMI_SUCCESS;
   }
-  if (result == QDMI_JOB_RESULT_HIST_KEYS) {
-    size_t raw_size = 0;
-    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, 0, nullptr,
-                              &raw_size);
-    std::string raw_data(raw_size, '\0');
-    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, raw_size,
-                              raw_data.data(), nullptr);
+  if (result == QDMI_JOB_RESULT_HIST_KEYS ||
+      result == QDMI_JOB_RESULT_HIST_VALUES) {
     // Count unique elements
-    std::unordered_map<std::string, size_t> hist;
-    std::stringstream ss(raw_data);
-    std::string token;
-    while (std::getline(ss, token, ',')) {
-      hist[token]++;
+    std::map<std::string, size_t> hist;
+    for (const auto &shot : job->results) {
+      hist[shot]++;
     }
     size_t num_qubits = 0;
     QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
                                    sizeof(size_t), &num_qubits, nullptr);
+    if (result == QDMI_JOB_RESULT_HIST_KEYS) {
+      const size_t req_size = hist.size() * (num_qubits + 1);
+      if (size_ret != nullptr) {
+        *size_ret = req_size;
+      }
+      if (data != nullptr) {
+        if (size < req_size) {
+          return QDMI_ERROR_INVALIDARGUMENT;
+        }
+        char *data_ptr = static_cast<char *>(data);
+        for (const auto &[bitstring, count] : hist) {
+          std::copy(bitstring.begin(), bitstring.end(), data_ptr);
+          data_ptr += bitstring.length();
+          *data_ptr++ = ',';
+        }
+        *(data_ptr - 1) = '\0'; // Replace last comma with null terminator
+      }
+      return QDMI_SUCCESS;
+    }
+
+    const size_t req_size = hist.size() * sizeof(size_t);
+    if (size_ret != nullptr) {
+      *size_ret = req_size;
+    }
     if (data != nullptr) {
-      if (size < hist.size() * (num_qubits + 1)) {
+      if (size < req_size) {
         return QDMI_ERROR_INVALIDARGUMENT;
       }
-      char *data_ptr = static_cast<char *>(data);
-      for (auto it = hist.begin(); it != hist.end(); ++it) {
-        const auto &k = it->first;
-        std::copy(k.begin(), k.end(), data_ptr);
-        data_ptr += k.length();
-        if (std::next(it) != hist.end()) {
-          *data_ptr++ = ','; // Add comma separator
-        } else {
-          *data_ptr++ = '\0'; // Add null terminator at the end
+      auto *data_ptr = static_cast<size_t *>(data);
+      for (const auto &[_, count] : hist) {
+        *data_ptr++ = count;
+      }
+    }
+    return QDMI_SUCCESS;
+  }
+  if (result == QDMI_JOB_RESULT_STATEVECTOR_DENSE) {
+    size_t num_qubits = 0;
+    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                   sizeof(size_t), &num_qubits, nullptr);
+    if (data != nullptr) {
+      if (size < (2ULL << num_qubits) * sizeof(double)) {
+        return QDMI_ERROR_INVALIDARGUMENT;
+      }
+      auto *data_ptr = static_cast<double *>(data);
+      for (const auto &c : job->state_vec) {
+        *data_ptr++ = c.real();
+        *data_ptr++ = c.imag();
+      }
+    }
+    if ((size_ret) != nullptr) {
+      *(size_ret) = (2ULL << num_qubits) * sizeof(double);
+    }
+    return QDMI_SUCCESS;
+  }
+  if (result == QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS) {
+    size_t dense_size = 0;
+    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_STATEVECTOR_DENSE, 0,
+                              nullptr, &dense_size);
+    std::vector<double> dense_data(
+        static_cast<std::size_t>(dense_size / sizeof(double)));
+    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_STATEVECTOR_DENSE,
+                              dense_size, dense_data.data(), nullptr);
+    size_t num_qubits = 0;
+    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                   sizeof(size_t), &num_qubits, nullptr);
+    // count non-zero elements
+    size_t count = 0;
+    for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
+      if (dense_data[2 * i] != 0.0 || dense_data[(2 * i) + 1] != 0.0) {
+        count++;
+      }
+    }
+    if (data != nullptr) {
+      if (size < count * (num_qubits + 1)) {
+        return QDMI_ERROR_INVALIDARGUMENT;
+      }
+      auto *data_ptr = static_cast<char *>(data);
+      for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
+        if (dense_data[2 * i] != 0.0 || dense_data[(2 * i) + 1] != 0.0) {
+          for (size_t j = 0; j < num_qubits; ++j) {
+            *data_ptr++ = ((i & (1 << (num_qubits - j - 1))) != 0U) ? '1' : '0';
+          }
+          *data_ptr++ = ',';
+        }
+      }
+      *(data_ptr - 1) = '\0'; // Replace last comma with null terminator
+    }
+    if ((size_ret) != nullptr) {
+      *(size_ret) = count * (num_qubits + 1);
+    }
+    return QDMI_SUCCESS;
+  }
+  if (result == QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES) {
+    size_t dense_size = 0;
+    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_STATEVECTOR_DENSE, 0,
+                              nullptr, &dense_size);
+    std::vector<double> dense_data(
+        static_cast<std::size_t>(dense_size / sizeof(double)));
+    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_STATEVECTOR_DENSE,
+                              dense_size, dense_data.data(), nullptr);
+    size_t num_qubits = 0;
+    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                   sizeof(size_t), &num_qubits, nullptr);
+    // count non-zero elements
+    size_t count = 0;
+    for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
+      if (dense_data[2 * i] != 0.0 || dense_data[(2 * i) + 1] != 0.0) {
+        count++;
+      }
+    }
+    if (data != nullptr) {
+      if (size < count * 2 * sizeof(double)) {
+        return QDMI_ERROR_INVALIDARGUMENT;
+      }
+      auto *data_ptr = static_cast<double *>(data);
+      for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
+        if (dense_data[2 * i] != 0.0 || dense_data[(2 * i) + 1] != 0.0) {
+          *data_ptr++ = dense_data[2 * i];
+          *data_ptr++ = dense_data[(2 * i) + 1];
         }
       }
     }
     if ((size_ret) != nullptr) {
-      *(size_ret) = hist.size() * (num_qubits + 1);
+      *(size_ret) = count * 2 * sizeof(double);
     }
     return QDMI_SUCCESS;
   }
-  if (result == QDMI_JOB_RESULT_HIST_VALUES) {
-    size_t raw_size = 0;
-    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, 0, nullptr,
-                              &raw_size);
-    std::string raw_data(raw_size, '\0');
-    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, raw_size,
-                              raw_data.data(), nullptr);
-    // Count unique elements
-    std::unordered_map<std::string, size_t> hist;
-    std::stringstream ss(raw_data);
-    std::string token;
-    while (std::getline(ss, token, ',')) {
-      hist[token]++;
-    }
-    size_t num_qubits = 0;
-    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
-                                   sizeof(size_t), &num_qubits, nullptr);
+  if (result == QDMI_JOB_RESULT_PROBABILITIES_DENSE) {
     if (data != nullptr) {
-      if (size < hist.size() * sizeof(size_t)) {
+      if (size < job->state_vec.size() * sizeof(double)) {
         return QDMI_ERROR_INVALIDARGUMENT;
       }
-      auto *data_ptr = static_cast<size_t *>(data);
-      for (const auto &[k, v] : hist) {
-        *data_ptr++ = v;
+      auto *data_ptr = static_cast<double *>(data);
+      for (const auto &c : job->state_vec) {
+        *data_ptr++ = std::norm(c);
       }
     }
     if ((size_ret) != nullptr) {
-      *(size_ret) = hist.size() * sizeof(size_t);
+      *(size_ret) = job->state_vec.size() * sizeof(double);
+    }
+    return QDMI_SUCCESS;
+  }
+  if (result == QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS) {
+    size_t dense_size = 0;
+    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_PROBABILITIES_DENSE, 0,
+                              nullptr, &dense_size);
+    std::vector<double> dense_data(dense_size / sizeof(double));
+    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_PROBABILITIES_DENSE,
+                              dense_size, dense_data.data(), nullptr);
+    size_t num_qubits = 0;
+    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                   sizeof(size_t), &num_qubits, nullptr);
+    // count non-zero elements
+    size_t count = 0;
+    for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
+      if (dense_data[i] != 0.0) {
+        count++;
+      }
+    }
+    if (data != nullptr) {
+      if (size < count * (num_qubits + 1)) {
+        return QDMI_ERROR_INVALIDARGUMENT;
+      }
+      auto *data_ptr = static_cast<char *>(data);
+      for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
+        if (dense_data[i] != 0.0) {
+          for (size_t j = 0; j < num_qubits; j++) {
+            *data_ptr++ = ((i & (1 << (num_qubits - j - 1))) != 0U) ? '1' : '0';
+          }
+          *data_ptr++ = ',';
+        }
+      }
+      *(data_ptr - 1) = '\0'; // Replace last comma with null terminator
+    }
+    if ((size_ret) != nullptr) {
+      *(size_ret) = count * (num_qubits + 1);
+    }
+    return QDMI_SUCCESS;
+  }
+  if (result == QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES) {
+    size_t dense_size = 0;
+    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_PROBABILITIES_DENSE, 0,
+                              nullptr, &dense_size);
+    std::vector<double> dense_data(
+        static_cast<std::size_t>(dense_size / sizeof(double)));
+    QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_PROBABILITIES_DENSE,
+                              dense_size, dense_data.data(), nullptr);
+    size_t num_qubits = 0;
+    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                   sizeof(size_t), &num_qubits, nullptr);
+    // count non-zero elements
+    size_t count = 0;
+    for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
+      if (dense_data[i] != 0.0) {
+        count++;
+      }
+    }
+    if (data != nullptr) {
+      if (size < count * sizeof(double)) {
+        return QDMI_ERROR_INVALIDARGUMENT;
+      }
+      auto *data_ptr = static_cast<double *>(data);
+      for (size_t i = 0; i < 1ULL << num_qubits; ++i) {
+        if (dense_data[i] != 0.0) {
+          *data_ptr++ = dense_data[i];
+        }
+      }
+    }
+    if ((size_ret) != nullptr) {
+      *(size_ret) = count * sizeof(double);
     }
     return QDMI_SUCCESS;
   }

--- a/include/qdmi/common/enums.h
+++ b/include/qdmi/common/enums.h
@@ -259,7 +259,7 @@ enum QDMI_JOB_RESULT_T {
   /**
    * @brief `char*`(string) The keys for the histogram of the results.
    * @details The histogram of the measurement results is represented as a
-   * key-value mapping. This mapping is returned as a list of keys and a
+   * key-value mapping. This mapping is returned as a list of keys and an
    * equal-length list of values. The corresponding partners of keys and values
    * can be found at the same index in the lists.
    *
@@ -272,6 +272,59 @@ enum QDMI_JOB_RESULT_T {
    * @see QDMI_JOB_RESULT_HIST_KEY
    */
   QDMI_JOB_RESULT_HIST_VALUES,
+  /**
+   * @brief `double*` (double list) The state vector of the result.
+   * @details The complex amplitudes are stored as a list of real and imaginary
+   * parts. The real part of the amplitude is at index 2n and the imaginary part
+   * is at index 2n+1. For example, the state vector of a 2-qubit system with
+   * amplitudes (0.5, 0.5), (0.5, -0.5), (-0.5, 0.5), (-0.5, -0.5) would be
+   * represented as `{0.5, 0.5, 0.5, -0.5, -0.5, 0.5, -0.5, -0.5}`.
+   */
+  QDMI_JOB_RESULT_STATEVECTOR_DENSE,
+  /**
+   * @brief `double*` (double list) The probabilities of the result.
+   * @details The probabilities are stored as a list of real numbers. The
+   * probability of the state with index n is at index n in the list. For
+   * example, the probabilities of a 2-qubit system with states 00, 01, 10, 11
+   * would be represented as `{0.25, 0.25, 0.25, 0.25}`.
+   */
+  QDMI_JOB_RESULT_PROBABILITIES_DENSE,
+  /**
+   * @brief `char*`(string) The keys for the sparse state vector of the result.
+   * @details The sparse state vector is represented as a key-value mapping.
+   * This mapping is returned as a list of keys and an equal-length list of
+   * values. The corresponding partners of keys and values can be found at the
+   * same index in the lists.
+   */
+  QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS,
+  /**
+   * @brief `double*` (double list) The values for the sparse state vector of
+   * the result.
+   * @details The complex amplitudes are stored in the same way as the dense
+   * state vector only that the values are only stored for the non-zero
+   * amplitudes.
+   * @see QDMI_JOB_RESULT_STATEVECTOR_DENSE
+   * @see QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS
+   */
+  QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES,
+  /**
+   * @brief `char*`(string) The keys for the sparse probabilities of the result.
+   * @details The sparse probabilities are represented as a key-value mapping.
+   * This mapping is returned as a list of keys and an equal-length list of
+   * values. The corresponding partners of keys and values can be found at the
+   * same index in the lists.
+   */
+  QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS,
+  /**
+   * @brief `double*` (double list) The values for the sparse probabilities of
+   * the result.
+   * @details The probabilities are stored in the same way as the dense
+   * probabilities only that the values are only stored for the non-zero
+   * probabilities.
+   * @see QDMI_JOB_RESULT_PROBABILITIES_DENSE
+   * @see QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS
+   */
+  QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES,
   /**
    * @brief This property is reserved for a custom property.
    * @details The meaning and the type of this property is defined by the

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -10,9 +10,8 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "utils/test_impl.hpp"
 
 #include <array>
-#include <cmath>
 #include <complex>
-#include <cstdlib>
+#include <cstddef>
 #include <gtest/gtest.h>
 #include <map>
 #include <sstream>
@@ -434,5 +433,134 @@ TEST_P(QDMIImplementationTest, ControlGetProbsSparse) {
   }
   ASSERT_NEAR(sum, 1.0, 1e-6);
 
+  QDMI_control_free_job(device, job);
+}
+
+TEST_P(QDMIImplementationTest, ControlGetShotsBufferTooSmall) {
+  QDMI_Job job = Submit_test_job(device, 64);
+  size_t size = 0;
+  ASSERT_EQ(QDMI_control_get_data(device, job, QDMI_JOB_RESULT_SHOTS, 0,
+                                  nullptr, &size),
+            QDMI_SUCCESS);
+  std::vector<char> buffer(size - 1); // Buffer too small
+  EXPECT_EQ(QDMI_control_get_data(device, job, QDMI_JOB_RESULT_SHOTS,
+                                  buffer.size(), buffer.data(), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+  QDMI_control_free_job(device, job);
+}
+
+TEST_P(QDMIImplementationTest, ControlGetHistogramKeysBufferTooSmall) {
+  QDMI_Job job = Submit_test_job(device, 64);
+  size_t size = 0;
+  ASSERT_EQ(QDMI_control_get_data(device, job, QDMI_JOB_RESULT_HIST_KEYS, 0,
+                                  nullptr, &size),
+            QDMI_SUCCESS);
+  std::vector<char> buffer(size - 1); // Buffer too small
+  EXPECT_EQ(QDMI_control_get_data(device, job, QDMI_JOB_RESULT_HIST_KEYS,
+                                  buffer.size(), buffer.data(), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+  QDMI_control_free_job(device, job);
+}
+
+TEST_P(QDMIImplementationTest, ControlGetHistogramValuesBufferTooSmall) {
+  QDMI_Job job = Submit_test_job(device, 64);
+  size_t size = 0;
+  ASSERT_EQ(QDMI_control_get_data(device, job, QDMI_JOB_RESULT_HIST_VALUES, 0,
+                                  nullptr, &size),
+            QDMI_SUCCESS);
+  std::vector<char> buffer(size - 1); // Buffer too small
+  EXPECT_EQ(QDMI_control_get_data(device, job, QDMI_JOB_RESULT_HIST_VALUES,
+                                  buffer.size(), buffer.data(), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+  QDMI_control_free_job(device, job);
+}
+
+TEST_P(QDMIImplementationTest, ControlGetStateDenseBufferTooSmall) {
+  QDMI_Job job = Submit_test_job(device);
+  size_t size = 0;
+  ASSERT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_STATEVECTOR_DENSE, 0, nullptr,
+                                  &size),
+            QDMI_SUCCESS);
+  std::vector<char> buffer(size - 1); // Buffer too small
+  EXPECT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_STATEVECTOR_DENSE,
+                                  buffer.size(), buffer.data(), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+  QDMI_control_free_job(device, job);
+}
+
+TEST_P(QDMIImplementationTest, ControlGetStateSparseKeysBufferTooSmall) {
+  QDMI_Job job = Submit_test_job(device);
+  size_t size = 0;
+  ASSERT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS, 0,
+                                  nullptr, &size),
+            QDMI_SUCCESS);
+  std::vector<char> buffer(size - 1); // Buffer too small
+  EXPECT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS,
+                                  buffer.size(), buffer.data(), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+  QDMI_control_free_job(device, job);
+}
+
+TEST_P(QDMIImplementationTest, ControlGetStateSparseValuesBufferTooSmall) {
+  QDMI_Job job = Submit_test_job(device);
+  size_t size = 0;
+  ASSERT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES, 0,
+                                  nullptr, &size),
+            QDMI_SUCCESS);
+  std::vector<char> buffer(size - 1); // Buffer too small
+  EXPECT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES,
+                                  buffer.size(), buffer.data(), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+  QDMI_control_free_job(device, job);
+}
+
+TEST_P(QDMIImplementationTest, ControlGetProbsDenseBufferTooSmall) {
+  QDMI_Job job = Submit_test_job(device);
+  size_t size = 0;
+  ASSERT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_PROBABILITIES_DENSE, 0,
+                                  nullptr, &size),
+            QDMI_SUCCESS);
+  std::vector<char> buffer(size - 1); // Buffer too small
+  EXPECT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_PROBABILITIES_DENSE,
+                                  buffer.size(), buffer.data(), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+  QDMI_control_free_job(device, job);
+}
+
+TEST_P(QDMIImplementationTest, ControlGetProbsSparseKeysBufferTooSmall) {
+  QDMI_Job job = Submit_test_job(device);
+  size_t size = 0;
+  ASSERT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS, 0,
+                                  nullptr, &size),
+            QDMI_SUCCESS);
+  std::vector<char> buffer(size - 1); // Buffer too small
+  EXPECT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS,
+                                  buffer.size(), buffer.data(), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+  QDMI_control_free_job(device, job);
+}
+
+TEST_P(QDMIImplementationTest, ControlGetProbsSparseValuesBufferTooSmall) {
+  QDMI_Job job = Submit_test_job(device);
+  size_t size = 0;
+  ASSERT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES,
+                                  0, nullptr, &size),
+            QDMI_SUCCESS);
+  std::vector<char> buffer(size - 1); // Buffer too small
+  EXPECT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES,
+                                  buffer.size(), buffer.data(), nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
   QDMI_control_free_job(device, job);
 }

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -10,11 +10,14 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "utils/test_impl.hpp"
 
 #include <array>
+#include <cmath>
 #include <cstdlib>
 #include <gtest/gtest.h>
 #include <map>
 #include <sstream>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 // Instantiate the test suite with different parameters
@@ -181,7 +184,7 @@ TEST_P(QDMIImplementationTest, ToolCompile) {
   ASSERT_EQ(actual, expected);
 }
 
-TEST_P(QDMIImplementationTest, ControlGetData) {
+TEST_P(QDMIImplementationTest, ControlGetShots) {
   const std::string test_circuit = R"(
 OPENQASM 2.0;
 include "qelib1.inc";
@@ -228,5 +231,135 @@ measure q -> c;
     results[key_vec[i]] = val_vec[i];
   }
   ASSERT_EQ(results.size(), size);
+  QDMI_control_free_job(device, job);
+}
+
+TEST_P(QDMIImplementationTest, ControlGetState) {
+  const std::string test_circuit = R"(
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+measure q -> c;
+  )";
+  QDMI_Job job = nullptr;
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    test_circuit.length() + 1,
+                                    test_circuit.c_str(), &job),
+            QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_submit_job(device, job), QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_wait(device, job), QDMI_SUCCESS);
+  int num_qubits = 0;
+  ASSERT_EQ(QDMI_query_device_property(device, QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                       0, &num_qubits, nullptr),
+            QDMI_SUCCESS);
+  std::vector<double> state_vector(
+      static_cast<std::size_t>(std::pow(2, num_qubits)) * 2);
+  ASSERT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_STATEVECTOR_DENSE,
+                                  sizeof(double) * state_vector.size(),
+                                  state_vector.data(), nullptr),
+            QDMI_SUCCESS);
+  size_t size = 0;
+  ASSERT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS, 0,
+                                  nullptr, &size),
+            QDMI_SUCCESS);
+  std::string key_list(size, '\0');
+  ASSERT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS, size,
+                                  key_list.data(), nullptr),
+            QDMI_SUCCESS);
+  std::vector<std::string> key_vec;
+  std::string token;
+  std::stringstream ss(key_list);
+  while (std::getline(ss, token, ',')) {
+    key_vec.emplace_back(token);
+  }
+  std::vector<double> val_vec(key_vec.size() * 2);
+  ASSERT_EQ(QDMI_control_get_data(
+                device, job, QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES,
+                sizeof(double) * val_vec.size(), val_vec.data(), nullptr),
+            QDMI_SUCCESS);
+  std::unordered_map<std::string, std::pair<double, double>> results;
+  for (size_t i = 0; i < key_vec.size(); ++i) {
+    results[key_vec[i]] = {val_vec[2 * i], val_vec[(2 * i) + 1]};
+    // transform bitstring key_vec[i] to integer
+    size_t key = 0;
+    for (size_t j = 0; j < key_vec[i].size(); ++j) {
+      key += static_cast<std::size_t>(key_vec[i][j] - '0') *
+             (1 << static_cast<std::size_t>(key_vec[i].size() - j - 1));
+    }
+    EXPECT_NEAR(state_vector[2 * key], val_vec[2 * i], 1e-6);
+    EXPECT_NEAR(state_vector[(2 * key) + 1], val_vec[(2 * i) + 1], 1e-6);
+  }
+  EXPECT_EQ(results.size(), key_vec.size());
+  QDMI_control_free_job(device, job);
+}
+
+TEST_P(QDMIImplementationTest, ControlGetProbs) {
+  const std::string test_circuit = R"(
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[2];
+h q[0];
+cx q[0], q[1];
+measure q -> c;
+  )";
+  QDMI_Job job = nullptr;
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    static_cast<int>(test_circuit.length() + 1),
+                                    test_circuit.c_str(), &job),
+            QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_submit_job(device, job), QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_wait(device, job), QDMI_SUCCESS);
+  int num_qubits = 0;
+  ASSERT_EQ(QDMI_query_device_property(device, QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                       sizeof(int), &num_qubits, nullptr),
+            QDMI_SUCCESS);
+  std::vector<double> state_vector(
+      static_cast<std::size_t>(std::pow(2, num_qubits)));
+  ASSERT_EQ(QDMI_control_get_data(
+                device, job, QDMI_JOB_RESULT_PROBABILITIES_DENSE,
+                static_cast<int>(sizeof(double) * state_vector.size()),
+                state_vector.data(), nullptr),
+            QDMI_SUCCESS);
+  int size = 0;
+  ASSERT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS, 0,
+                                  nullptr, &size),
+            QDMI_SUCCESS);
+  std::string key_list(static_cast<std::size_t>(size - 1), '\0');
+  ASSERT_EQ(QDMI_control_get_data(device, job,
+                                  QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS,
+                                  size, key_list.data(), nullptr),
+            QDMI_SUCCESS);
+  std::vector<std::string> key_vec;
+  std::string token;
+  std::stringstream ss(key_list);
+  while (std::getline(ss, token, ',')) {
+    key_vec.emplace_back(token);
+  }
+  std::vector<double> val_vec(key_vec.size());
+  ASSERT_EQ(QDMI_control_get_data(
+                device, job, QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES,
+                static_cast<int>(sizeof(double) * val_vec.size()),
+                val_vec.data(), nullptr),
+            QDMI_SUCCESS);
+  std::unordered_map<std::string, double> results;
+  for (size_t i = 0; i < key_vec.size(); ++i) {
+    results[key_vec[i]] = val_vec[i];
+    // transform bitstring key_vec[i] to integer
+    size_t key = 0;
+    for (size_t j = 0; j < key_vec[i].size(); ++j) {
+      key += static_cast<std::size_t>(key_vec[i][j] - '0') *
+             (1 << static_cast<std::size_t>(key_vec[i].size() - j - 1));
+    }
+    EXPECT_NEAR(state_vector[key], val_vec[i], 1e-6);
+  }
+  EXPECT_EQ(results.size(), key_vec.size());
   QDMI_control_free_job(device, job);
 }


### PR DESCRIPTION
### Issue

As discussed in #80, more readout formats are desired, esp., in the case when the QDMI device is a simulator.

### Solution

This PR adds the readout types and implements the corresponding behaviour in both example devices.
```C
QDMI_JOB_RESULT_STATEVECTOR_DENSE,
QDMI_JOB_RESULT_PROBABILITIES_DENSE,
QDMI_JOB_RESULT_STATEVECTOR_SPARSE_KEYS,
QDMI_JOB_RESULT_STATEVECTOR_SPARSE_VALUES,
QDMI_JOB_RESULT_PROBABILITIES_SPARSE_KEYS,
QDMI_JOB_RESULT_PROBABILITIES_SPARSE_VALUES,
```