### PR TITLE
🎨 Use `size_t` for buffer sizes and countable quantities in general

### DIFF
--- a/examples/device/c/device.c
+++ b/examples/device/c/device.c
@@ -18,12 +18,12 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 typedef struct QDMI_Job_impl_d {
   int id;
   QDMI_Job_Status status;
-  int num_shots;
+  size_t num_shots;
   char *results;
 } QDMI_Job_impl_t;
 
 typedef struct QDMI_Site_impl_d {
-  int id;
+  size_t id;
 } QDMI_Site_impl_t;
 
 typedef struct QDMI_Operation_impl_d {
@@ -98,7 +98,7 @@ const QDMI_Operation DEVICE_OPERATIONS[] = {
         ((char *)(value))[(size) - 1] = '\0';                                  \
       }                                                                        \
       if ((size_ret) != NULL) {                                                \
-        *(size_ret) = (int)strlen(prop_value) + 1;                             \
+        *(size_ret) = strlen(prop_value) + 1;                                  \
       }                                                                        \
       return QDMI_SUCCESS;                                                     \
     }                                                                          \
@@ -116,15 +116,15 @@ const QDMI_Operation DEVICE_OPERATIONS[] = {
                (prop_length) * sizeof(prop_type));                             \
       }                                                                        \
       if ((size_ret) != NULL) {                                                \
-        *(size_ret) = (prop_length) * (int)sizeof(prop_type);                  \
+        *(size_ret) = (prop_length) * sizeof(prop_type);                       \
       }                                                                        \
       return QDMI_SUCCESS;                                                     \
     }                                                                          \
   }
 
-int QDMI_query_get_sites_dev(const int num_entries, QDMI_Site *sites,
-                             int *num_sites) {
-  if ((sites != NULL && num_entries <= 0) ||
+int QDMI_query_get_sites_dev(const size_t num_entries, QDMI_Site *sites,
+                             size_t *num_sites) {
+  if ((sites != NULL && num_entries == 0) ||
       (sites == NULL && num_sites == NULL)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -137,15 +137,15 @@ int QDMI_query_get_sites_dev(const int num_entries, QDMI_Site *sites,
            copy_size * sizeof(QDMI_Site));
   }
   if (num_sites != NULL) {
-    *num_sites = (int)device_sites_size;
+    *num_sites = device_sites_size;
   }
   return QDMI_SUCCESS;
 } /// [DOXYGEN FUNCTION END]
 
-int QDMI_query_get_operations_dev(const int num_entries,
+int QDMI_query_get_operations_dev(const size_t num_entries,
                                   QDMI_Operation *operations,
-                                  int *num_operations) {
-  if ((operations != NULL && num_entries <= 0) ||
+                                  size_t *num_operations) {
+  if ((operations != NULL && num_entries == 0) ||
       (operations == NULL && num_operations == NULL)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -159,13 +159,14 @@ int QDMI_query_get_operations_dev(const int num_entries,
            copy_size * sizeof(QDMI_Operation));
   }
   if (num_operations != NULL) {
-    *num_operations = (int)device_operations_size;
+    *num_operations = device_operations_size;
   }
   return QDMI_SUCCESS;
 } /// [DOXYGEN FUNCTION END]
 
 int QDMI_query_device_property_dev(const QDMI_Device_Property prop,
-                                   const int size, void *value, int *size_ret) {
+                                   const size_t size, void *value,
+                                   size_t *size_ret) {
   if (prop >= QDMI_DEVICE_PROPERTY_MAX || (value == NULL && size_ret == NULL)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -175,8 +176,8 @@ int QDMI_query_device_property_dev(const QDMI_Device_Property prop,
                       size_ret)
   ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_LIBRARYVERSION, "1.0.0b1", prop,
                       size, value, size_ret)
-  ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_QUBITSNUM, int, 5, prop, size,
-                            value, size_ret)
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_QUBITSNUM, size_t, 5, prop,
+                            size, value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_STATUS, QDMI_Device_Status,
                             QDMI_read_device_status(), prop, size, value,
                             size_ret)
@@ -194,7 +195,7 @@ int QDMI_query_device_property_dev(const QDMI_Device_Property prop,
 
 int QDMI_query_site_property_dev(
     QDMI_Site site, QDMI_Site_Property prop, // NOLINT(*-unused-parameter*)
-    int size, void *value, int *size_ret) {
+    size_t size, void *value, size_t *size_ret) {
   if (prop >= QDMI_SITE_PROPERTY_MAX || (value == NULL && size_ret == NULL)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -206,13 +207,13 @@ int QDMI_query_site_property_dev(
 } /// [DOXYGEN FUNCTION END]
 
 int QDMI_query_operation_property_dev(QDMI_Operation operation,
-                                      const int num_sites,
+                                      const size_t num_sites,
                                       const QDMI_Site *sites,
                                       const QDMI_Operation_Property prop,
-                                      const int size, void *value,
-                                      int *size_ret) {
+                                      const size_t size, void *value,
+                                      size_t *size_ret) {
   if (prop >= QDMI_OPERATION_PROPERTY_MAX || operation == NULL ||
-      (sites != NULL && num_sites <= 0) ||
+      (sites != NULL && num_sites == 0) ||
       (value == NULL && size_ret == NULL)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -227,8 +228,8 @@ int QDMI_query_operation_property_dev(QDMI_Operation operation,
     ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_DURATION, double, 0.01,
                               prop, size, value, size_ret)
     if (sites == NULL) {
-      ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_QUBITSNUM, int, 2, prop,
-                                size, value, size_ret)
+      ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_QUBITSNUM, size_t, 2,
+                                prop, size, value, size_ret)
       return QDMI_ERROR_NOTSUPPORTED;
     }
     if (sites[0] == sites[1]) {
@@ -272,8 +273,8 @@ int QDMI_query_operation_property_dev(QDMI_Operation operation,
     }
     ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_DURATION, double, 0.01,
                               prop, size, value, size_ret)
-    ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_QUBITSNUM, int, 1, prop,
-                              size, value, size_ret)
+    ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_QUBITSNUM, size_t, 1,
+                              prop, size, value, size_ret)
     ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_FIDELITY, double, 0.999,
                               prop, size, value, size_ret)
   }
@@ -281,12 +282,12 @@ int QDMI_query_operation_property_dev(QDMI_Operation operation,
 } /// [DOXYGEN FUNCTION END]
 
 int QDMI_control_create_job_dev(const QDMI_Program_Format format,
-                                const int size, const void *prog,
+                                const size_t size, const void *prog,
                                 QDMI_Job *job) {
   if (QDMI_read_device_status() != QDMI_DEVICE_STATUS_IDLE) {
     return QDMI_ERROR_FATAL;
   }
-  if (size <= 0 || prog == NULL || job == NULL) {
+  if (size == 0 || prog == NULL || job == NULL) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (format != QDMI_PROGRAM_FORMAT_QASM2 &&
@@ -306,13 +307,13 @@ int QDMI_control_create_job_dev(const QDMI_Program_Format format,
 } /// [DOXYGEN FUNCTION END]
 
 int QDMI_control_set_parameter_dev(QDMI_Job job, const QDMI_Job_Parameter param,
-                                   const int size, const void *value) {
-  if (job == NULL || param >= QDMI_JOB_PARAMETER_MAX || size <= 0 ||
+                                   const size_t size, const void *value) {
+  if (job == NULL || param >= QDMI_JOB_PARAMETER_MAX || size == 0 ||
       job->status != QDMI_JOB_STATUS_CREATED) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (param == QDMI_JOB_PARAMETER_SHOTS_NUM) {
-    job->num_shots = *(const int *)value;
+    job->num_shots = *(const size_t *)value;
     return QDMI_SUCCESS;
   }
   return QDMI_ERROR_NOTSUPPORTED;
@@ -329,13 +330,13 @@ int QDMI_control_submit_job_dev(QDMI_Job job) {
   // set job status to running for demonstration purposes
   job->status = QDMI_JOB_STATUS_RUNNING;
   // generate random result data
-  int num_qubits = 0;
-  QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(int),
+  size_t num_qubits = 0;
+  QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(size_t),
                                  &num_qubits, NULL);
-  job->results = (char *)malloc((size_t)job->num_shots * (num_qubits + 1));
-  for (int i = 0; i < job->num_shots; i++) {
+  job->results = (char *)malloc(job->num_shots * (num_qubits + 1));
+  for (size_t i = 0; i < job->num_shots; ++i) {
     // generate random 5-bit string
-    for (int j = 0; j < 5; j++) {
+    for (size_t j = 0; j < 5; ++j) {
       *(job->results + (i * (num_qubits + 1) + j)) = (rand() % 2) ? '1' : '0';
     }
     if (i < job->num_shots - 1) {
@@ -380,15 +381,15 @@ int QDMI_Compare_results(const void *a, const void *b) {
 } /// [DOXYGEN FUNCTION END]
 
 int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
-                              const int size, void *data, int *size_ret) {
+                              const size_t size, void *data, size_t *size_ret) {
   if (job->status != QDMI_JOB_STATUS_DONE) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (result == QDMI_JOB_RESULT_SHOTS) {
     // generate random measurement results
-    int num_qubits = 0;
-    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(int),
-                                   &num_qubits, NULL);
+    size_t num_qubits = 0;
+    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                   sizeof(size_t), &num_qubits, NULL);
     if (data != NULL) {
       if (size < job->num_shots * (num_qubits + 1)) {
         return QDMI_ERROR_INVALIDARGUMENT;
@@ -401,14 +402,13 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
     return QDMI_SUCCESS;
   }
   if (result == QDMI_JOB_RESULT_HIST_KEYS) {
-    int raw_size = 0;
+    size_t raw_size = 0;
     QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, 0, NULL, &raw_size);
     char *raw_data = malloc(raw_size);
     QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, raw_size, raw_data,
                               NULL);
     // split the string at the commas
-    char **raw_data_split =
-        (char **)malloc(sizeof(char *) * (size_t)job->num_shots);
+    char **raw_data_split = (char **)malloc(sizeof(char *) * job->num_shots);
     char *token = strtok(raw_data, ",");
     int i = 0;
     while (token != NULL) {
@@ -420,36 +420,37 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
     qsort((void *)raw_data_split, job->num_shots, sizeof(char *),
           QDMI_Compare_results);
     // Count unique elements
-    int count = 1; // First element is always unique
-    for (int j = 1; j < job->num_shots; j++) {
+    size_t count = 1; // First element is always unique
+    for (size_t j = 1; j < job->num_shots; ++j) {
       if (strcmp(raw_data_split[j], raw_data_split[j - 1]) != 0) {
         count++;
       }
     }
-    int num_qubits = 0;
-    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(int),
-                                   &num_qubits, NULL);
+    size_t num_qubits = 0;
+    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                   sizeof(size_t), &num_qubits, NULL);
     if (data != NULL) {
       if (size < count * (num_qubits + 1)) {
         free((void *)raw_data_split);
         free(raw_data);
         return QDMI_ERROR_INVALIDARGUMENT;
       }
-      strcpy((char *)data, raw_data_split[0]);
-      data += num_qubits;
+      char *data_ptr = (char *)data;
+      strcpy(data_ptr, raw_data_split[0]);
+      data_ptr += num_qubits;
       if (count > 1) {
-        *(char *)data = ',';
+        *data_ptr = ',';
       }
-      data += 1;
-      int k = 1;
-      for (int j = 1; j < job->num_shots; j++) {
+      data_ptr += 1;
+      size_t k = 1;
+      for (size_t j = 1; j < job->num_shots; ++j) {
         if (strcmp(raw_data_split[j], raw_data_split[j - 1]) != 0) {
-          strcpy((char *)data, raw_data_split[j]);
-          data += num_qubits;
+          strcpy(data_ptr, raw_data_split[j]);
+          data_ptr += num_qubits;
           if (k < count - 1) {
-            *(char *)data = ',';
+            *data_ptr = ',';
           }
-          data += 1;
+          data_ptr += 1;
           ++k;
         }
       }
@@ -462,14 +463,13 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
     return QDMI_SUCCESS;
   }
   if (result == QDMI_JOB_RESULT_HIST_VALUES) {
-    int raw_size = 0;
+    size_t raw_size = 0;
     QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, 0, NULL, &raw_size);
     char *raw_data = malloc(raw_size);
     QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, raw_size, raw_data,
                               NULL);
     // split the string at the commas
-    char **raw_data_split =
-        (char **)malloc(sizeof(char *) * (unsigned long)job->num_shots);
+    char **raw_data_split = (char **)malloc(sizeof(char *) * job->num_shots);
     char *token = strtok(raw_data, ",");
     int i = 0;
     while (token != NULL) {
@@ -481,26 +481,26 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
     qsort((void *)raw_data_split, job->num_shots, sizeof(char *),
           QDMI_Compare_results);
     // Count unique elements
-    int count = 1; // First element is always unique
-    for (int j = 1; j < job->num_shots; j++) {
+    size_t count = 1; // First element is always unique
+    for (size_t j = 1; j < job->num_shots; ++j) {
       if (strcmp(raw_data_split[j], raw_data_split[j - 1]) != 0) {
         count++;
       }
     }
-    int num_qubits = 0;
-    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(int),
-                                   &num_qubits, NULL);
+    size_t num_qubits = 0;
+    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                   sizeof(size_t), &num_qubits, NULL);
     if (data != NULL) {
-      if (size < sizeof(int) * count) {
+      if (size < sizeof(size_t) * count) {
         free((void *)raw_data_split);
         free(raw_data);
         return QDMI_ERROR_INVALIDARGUMENT;
       }
-      int n = 1;
-      for (int j = 1; j < job->num_shots; j++) {
+      size_t n = 1;
+      size_t *data_ptr = (size_t *)data;
+      for (size_t j = 1; j < job->num_shots; ++j) {
         if (strcmp(raw_data_split[j], raw_data_split[j - 1]) != 0) {
-          *(int *)data = n;
-          data += sizeof(int);
+          *data_ptr++ = n;
           n = 1;
         } else {
           ++n;
@@ -508,7 +508,7 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
       }
     }
     if ((size_ret) != NULL) {
-      *(size_ret) = (int)sizeof(int) * count;
+      *(size_ret) = sizeof(size_t) * count;
     }
     free((void *)raw_data_split);
     free(raw_data);

--- a/examples/device/c/device.c
+++ b/examples/device/c/device.c
@@ -36,7 +36,7 @@ typedef struct QDMI_Operation_impl_d {
  * @note This function is considered private and should not be used outside of
  * this file. Hence, it is not part of any header file.
  */
-static QDMI_Device_Status *QDMI_get_device_status() {
+static QDMI_Device_Status *QDMI_get_device_status(void) {
   static QDMI_Device_Status device_status = QDMI_DEVICE_STATUS_OFFLINE;
   return &device_status;
 }
@@ -57,7 +57,7 @@ void QDMI_set_device_status(QDMI_Device_Status status) {
  * @note This function is considered private and should not be used outside of
  * this file. Hence, it is not part of any header file.
  */
-QDMI_Device_Status QDMI_read_device_status() {
+QDMI_Device_Status QDMI_read_device_status(void) {
   return *QDMI_get_device_status();
 }
 

--- a/examples/device/cxx/device.cpp
+++ b/examples/device/cxx/device.cpp
@@ -57,7 +57,7 @@ std::array<QDMI_Operation_impl_d, 4> device_operations = {
     QDMI_Operation_impl_d{"rx"}, QDMI_Operation_impl_d{"ry"},
     QDMI_Operation_impl_d{"rz"}, QDMI_Operation_impl_d{"cx"}};
 
-std::array<QDMI_Site_impl_d, 7> device_sites = {
+std::array<QDMI_Site_impl_d, 5> device_sites = {
     QDMI_Site_impl_d{0}, QDMI_Site_impl_d{1}, QDMI_Site_impl_d{2},
     QDMI_Site_impl_d{3}, QDMI_Site_impl_d{4}};
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)

--- a/examples/device/cxx/device.cpp
+++ b/examples/device/cxx/device.cpp
@@ -28,13 +28,13 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 struct QDMI_Job_impl_d {
   int id = 0;
   QDMI_Job_Status status = QDMI_JOB_STATUS_SUBMITTED;
-  int num_shots = 0;
+  size_t num_shots = 0;
   std::vector<std::string> results;
   std::bernoulli_distribution binary_dist{0.5};
 };
 
 struct QDMI_Site_impl_d {
-  int id;
+  size_t id;
 };
 
 struct QDMI_Operation_impl_d {
@@ -145,7 +145,7 @@ const static std::unordered_map<
         static_cast<char *>(value)[size - 1] = '\0';                           \
       }                                                                        \
       if ((size_ret) != nullptr) {                                             \
-        *(size_ret) = static_cast<int>(strlen(prop_value)) + 1;                \
+        *(size_ret) = strlen(prop_value) + 1;                                  \
       }                                                                        \
       return QDMI_SUCCESS;                                                     \
     }                                                                          \
@@ -164,54 +164,52 @@ const static std::unordered_map<
                (prop_values).size() * sizeof(prop_type));                      \
       }                                                                        \
       if ((size_ret) != nullptr) {                                             \
-        *(size_ret) = (int)((prop_values).size() * sizeof(prop_type));         \
+        *(size_ret) = (prop_values).size() * sizeof(prop_type);                \
       }                                                                        \
       return QDMI_SUCCESS;                                                     \
     }                                                                          \
   }
 // NOLINTEND(bugprone-macro-parentheses)
 
-int QDMI_query_get_sites_dev(const int num_entries, QDMI_Site *sites,
-                             int *num_sites) {
-  if ((sites != nullptr && num_entries <= 0) ||
+int QDMI_query_get_sites_dev(const size_t num_entries, QDMI_Site *sites,
+                             size_t *num_sites) {
+  if ((sites != nullptr && num_entries == 0) ||
       (sites == nullptr && num_sites == nullptr)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (sites != nullptr) {
-    for (int i = 0;
-         i < std::min(num_entries, static_cast<int>(device_sites.size()));
-         ++i) {
+    for (size_t i = 0; i < std::min(num_entries, device_sites.size()); ++i) {
       sites[i] = &device_sites[i];
     }
   }
   if (num_sites != nullptr) {
-    *num_sites = static_cast<int>(device_sites.size());
+    *num_sites = device_sites.size();
   }
   return QDMI_SUCCESS;
 } /// [DOXYGEN FUNCTION END]
 
-int QDMI_query_get_operations_dev(const int num_entries,
+int QDMI_query_get_operations_dev(const size_t num_entries,
                                   QDMI_Operation *operations,
-                                  int *num_operations) {
-  if ((operations != nullptr && num_entries <= 0) ||
+                                  size_t *num_operations) {
+  if ((operations != nullptr && num_entries == 0) ||
       (operations == nullptr && num_operations == nullptr)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (operations != nullptr) {
-    for (int i = 0;
-         i < std::min(num_entries, static_cast<int>(device_operations.size()));
+    for (size_t i = 0; i < std::min(num_entries, device_operations.size());
          ++i) {
       operations[i] = &device_operations[i];
     }
   }
   if (num_operations != nullptr) {
-    *num_operations = static_cast<int>(device_operations.size());
+    *num_operations = device_operations.size();
   }
   return QDMI_SUCCESS;
 } /// [DOXYGEN FUNCTION END]
 
 int QDMI_query_device_property_dev(const QDMI_Device_Property prop,
-                                   const int size, void *value, int *size_ret) {
+                                   const size_t size, void *value,
+                                   size_t *size_ret) {
   if (prop >= QDMI_DEVICE_PROPERTY_MAX ||
       (value == nullptr && size_ret == nullptr)) {
     return QDMI_ERROR_INVALIDARGUMENT;
@@ -222,8 +220,8 @@ int QDMI_query_device_property_dev(const QDMI_Device_Property prop,
                       size_ret)
   ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_LIBRARYVERSION, "1.0.0b1", prop,
                       size, value, size_ret)
-  ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_QUBITSNUM, int, 5, prop, size,
-                            value, size_ret)
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_QUBITSNUM, size_t, 5, prop,
+                            size, value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_STATUS, QDMI_Device_Status,
                             device_state.status, prop, size, value, size_ret)
   ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_COUPLINGMAP, QDMI_Site,
@@ -232,8 +230,8 @@ int QDMI_query_device_property_dev(const QDMI_Device_Property prop,
 } /// [DOXYGEN FUNCTION END]
 
 int QDMI_query_site_property_dev([[maybe_unused]] QDMI_Site site,
-                                 QDMI_Site_Property prop, int size, void *value,
-                                 int *size_ret) {
+                                 QDMI_Site_Property prop, size_t size,
+                                 void *value, size_t *size_ret) {
   if (prop >= QDMI_SITE_PROPERTY_MAX ||
       (value == nullptr && size_ret == nullptr)) {
     return QDMI_ERROR_INVALIDARGUMENT;
@@ -245,12 +243,12 @@ int QDMI_query_site_property_dev([[maybe_unused]] QDMI_Site site,
   return QDMI_ERROR_NOTSUPPORTED;
 } /// [DOXYGEN FUNCTION END]
 
-int QDMI_query_operation_property_dev(QDMI_Operation operation, int num_sites,
-                                      const QDMI_Site *sites,
-                                      QDMI_Operation_Property prop, int size,
-                                      void *value, int *size_ret) {
+int QDMI_query_operation_property_dev(QDMI_Operation operation,
+                                      size_t num_sites, const QDMI_Site *sites,
+                                      QDMI_Operation_Property prop, size_t size,
+                                      void *value, size_t *size_ret) {
   if (prop >= QDMI_OPERATION_PROPERTY_MAX || operation == nullptr ||
-      (sites != nullptr && num_sites <= 0) ||
+      (sites != nullptr && num_sites == 0) ||
       (value == nullptr && size_ret == nullptr)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -265,8 +263,8 @@ int QDMI_query_operation_property_dev(QDMI_Operation operation, int num_sites,
                               OPERATION_DURATIONS.at(operation), prop, size,
                               value, size_ret)
     if (sites == nullptr) {
-      ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_QUBITSNUM, int, 2, prop,
-                                size, value, size_ret)
+      ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_QUBITSNUM, size_t, 2,
+                                prop, size, value, size_ret)
       return QDMI_ERROR_NOTSUPPORTED;
     }
     const std::pair site_pair = {sites[0], sites[1]};
@@ -291,8 +289,8 @@ int QDMI_query_operation_property_dev(QDMI_Operation operation, int num_sites,
     }
     ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_DURATION, double, 0.01,
                               prop, size, value, size_ret)
-    ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_QUBITSNUM, int, 1, prop,
-                              size, value, size_ret)
+    ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_QUBITSNUM, size_t, 1,
+                              prop, size, value, size_ret)
     ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_FIDELITY, double, 0.999,
                               prop, size, value, size_ret)
   }
@@ -300,12 +298,12 @@ int QDMI_query_operation_property_dev(QDMI_Operation operation, int num_sites,
 } /// [DOXYGEN FUNCTION END]
 
 int QDMI_control_create_job_dev(const QDMI_Program_Format format,
-                                const int size, const void *prog,
+                                const size_t size, const void *prog,
                                 QDMI_Job *job) {
   if (device_state.status != QDMI_DEVICE_STATUS_IDLE) {
     return QDMI_ERROR_FATAL;
   }
-  if (size <= 0 || prog == nullptr || job == nullptr) {
+  if (size == 0 || prog == nullptr || job == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (format != QDMI_PROGRAM_FORMAT_QASM2 &&
@@ -323,13 +321,13 @@ int QDMI_control_create_job_dev(const QDMI_Program_Format format,
 } /// [DOXYGEN FUNCTION END]
 
 int QDMI_control_set_parameter_dev(QDMI_Job job, const QDMI_Job_Parameter param,
-                                   const int size, const void *value) {
-  if (job == nullptr || param >= QDMI_JOB_PARAMETER_MAX || size <= 0 ||
+                                   const size_t size, const void *value) {
+  if (job == nullptr || param >= QDMI_JOB_PARAMETER_MAX || size == 0 ||
       job->status != QDMI_JOB_STATUS_CREATED) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (param == QDMI_JOB_PARAMETER_SHOTS_NUM) {
-    job->num_shots = *static_cast<const int *>(value);
+    job->num_shots = *static_cast<const size_t *>(value);
     return QDMI_SUCCESS;
   }
   return QDMI_ERROR_NOTSUPPORTED;
@@ -346,12 +344,12 @@ int QDMI_control_submit_job_dev(QDMI_Job job) {
   // set job status to running for demonstration purposes
   job->status = QDMI_JOB_STATUS_RUNNING;
   // generate random result data
-  int num_qubits = 0;
-  QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(int),
+  size_t num_qubits = 0;
+  QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(size_t),
                                  &num_qubits, nullptr);
   job->results.clear();
   job->results.reserve(job->num_shots);
-  for (int i = 0; i < job->num_shots; i++) {
+  for (size_t i = 0; i < job->num_shots; ++i) {
     // generate random 5-bit string
     std::string result(num_qubits, '0');
     std::generate(result.begin(), result.end(), [&]() {
@@ -390,15 +388,15 @@ int QDMI_control_wait_dev(QDMI_Job job) {
 } /// [DOXYGEN FUNCTION END]
 
 int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
-                              const int size, void *data, int *size_ret) {
+                              const size_t size, void *data, size_t *size_ret) {
   if (job->status != QDMI_JOB_STATUS_DONE) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (result == QDMI_JOB_RESULT_SHOTS) {
     // generate random measurement results
-    int num_qubits = 0;
-    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(int),
-                                   &num_qubits, nullptr);
+    size_t num_qubits = 0;
+    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                   sizeof(size_t), &num_qubits, nullptr);
     if (data != nullptr) {
       if (size < job->num_shots * (num_qubits + 1)) {
         return QDMI_ERROR_INVALIDARGUMENT;
@@ -419,22 +417,22 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
     return QDMI_SUCCESS;
   }
   if (result == QDMI_JOB_RESULT_HIST_KEYS) {
-    int raw_size = 0;
+    size_t raw_size = 0;
     QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, 0, nullptr,
                               &raw_size);
     std::string raw_data(raw_size, '\0');
     QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, raw_size,
                               raw_data.data(), nullptr);
     // Count unique elements
-    std::unordered_map<std::string, int> hist;
+    std::unordered_map<std::string, size_t> hist;
     std::stringstream ss(raw_data);
     std::string token;
     while (std::getline(ss, token, ',')) {
       hist[token]++;
     }
-    int num_qubits = 0;
-    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(int),
-                                   &num_qubits, nullptr);
+    size_t num_qubits = 0;
+    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                   sizeof(size_t), &num_qubits, nullptr);
     if (data != nullptr) {
       if (size < hist.size() * (num_qubits + 1)) {
         return QDMI_ERROR_INVALIDARGUMENT;
@@ -452,39 +450,38 @@ int QDMI_control_get_data_dev(QDMI_Job job, const QDMI_Job_Result result,
       }
     }
     if ((size_ret) != nullptr) {
-      *(size_ret) = static_cast<int>(hist.size()) * (num_qubits + 1);
+      *(size_ret) = hist.size() * (num_qubits + 1);
     }
     return QDMI_SUCCESS;
   }
   if (result == QDMI_JOB_RESULT_HIST_VALUES) {
-    int raw_size = 0;
+    size_t raw_size = 0;
     QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, 0, nullptr,
                               &raw_size);
     std::string raw_data(raw_size, '\0');
     QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_SHOTS, raw_size,
                               raw_data.data(), nullptr);
     // Count unique elements
-    std::unordered_map<std::string, int> hist;
+    std::unordered_map<std::string, size_t> hist;
     std::stringstream ss(raw_data);
     std::string token;
     while (std::getline(ss, token, ',')) {
       hist[token]++;
     }
-    int num_qubits = 0;
-    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM, sizeof(int),
-                                   &num_qubits, nullptr);
+    size_t num_qubits = 0;
+    QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
+                                   sizeof(size_t), &num_qubits, nullptr);
     if (data != nullptr) {
-      if (size < hist.size() * sizeof(int)) {
+      if (size < hist.size() * sizeof(size_t)) {
         return QDMI_ERROR_INVALIDARGUMENT;
       }
-      int *int_data = static_cast<int *>(data);
+      auto *data_ptr = static_cast<size_t *>(data);
       for (const auto &[k, v] : hist) {
-        *int_data = v;
-        int_data++;
+        *data_ptr++ = v;
       }
     }
     if ((size_ret) != nullptr) {
-      *(size_ret) = static_cast<int>(hist.size() * sizeof(int));
+      *(size_ret) = hist.size() * sizeof(size_t);
     }
     return QDMI_SUCCESS;
   }

--- a/examples/driver/qdmi_example_driver.cpp
+++ b/examples/driver/qdmi_example_driver.cpp
@@ -241,9 +241,9 @@ int QDMI_session_alloc(QDMI_Session *session) {
   return QDMI_SUCCESS;
 }
 
-int QDMI_session_get_devices(QDMI_Session session, const int num_entries,
-                             QDMI_Device *devices, int *num_devices) {
-  if ((num_entries <= 0 && devices != nullptr) ||
+int QDMI_session_get_devices(QDMI_Session session, const size_t num_entries,
+                             QDMI_Device *devices, size_t *num_devices) {
+  if ((num_entries == 0 && devices != nullptr) ||
       (devices == nullptr && num_devices == nullptr)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
@@ -257,15 +257,15 @@ int QDMI_session_get_devices(QDMI_Session session, const int num_entries,
     return QDMI_SUCCESS;
   }
 
-  const auto num_devices_in_session =
-      static_cast<int>(session->device_list.size());
+  const auto num_devices_in_session = session->device_list.size();
   if (devices == nullptr) {
     *num_devices = num_devices_in_session;
     return QDMI_SUCCESS;
   }
 
-  const int num_devices_to_copy = std::min(num_entries, num_devices_in_session);
-  for (int i = 0; i < num_devices_to_copy; ++i) {
+  const auto num_devices_to_copy =
+      std::min(num_entries, num_devices_in_session);
+  for (size_t i = 0; i < num_devices_to_copy; ++i) {
     devices[i] = session->device_list[i].get();
   }
   if (num_devices != nullptr) {
@@ -288,37 +288,42 @@ int QDMI_Driver_shutdown() {
  * @{
  */
 
-int QDMI_query_get_sites(QDMI_Device device, const int num_entries,
-                         QDMI_Site *sites, int *num_sites) {
+int QDMI_query_get_sites(QDMI_Device device, const size_t num_entries,
+                         QDMI_Site *sites, size_t *num_sites) {
   return device->query_get_sites(num_entries, sites, num_sites);
 }
 
-int QDMI_query_get_operations(QDMI_Device device, const int num_entries,
-                              QDMI_Operation *operations, int *num_operations) {
+int QDMI_query_get_operations(QDMI_Device device, const size_t num_entries,
+                              QDMI_Operation *operations,
+                              size_t *num_operations) {
   return device->query_get_operations(num_entries, operations, num_operations);
 }
 
 int QDMI_query_device_property(QDMI_Device device, QDMI_Device_Property prop,
-                               const int size, void *value, int *size_ret) {
+                               const size_t size, void *value,
+                               size_t *size_ret) {
   return device->query_device_property(prop, size, value, size_ret);
 }
 
 int QDMI_query_site_property(QDMI_Device device, QDMI_Site site,
-                             QDMI_Site_Property prop, const int size,
-                             void *value, int *size_ret) {
+                             QDMI_Site_Property prop, const size_t size,
+                             void *value, size_t *size_ret) {
   return device->query_site_property(site, prop, size, value, size_ret);
 }
 
 int QDMI_query_operation_property(QDMI_Device device, QDMI_Operation operation,
-                                  const int num_sites, const QDMI_Site *sites,
-                                  QDMI_Operation_Property prop, const int size,
-                                  void *value, int *size_ret) {
+                                  const size_t num_sites,
+                                  const QDMI_Site *sites,
+                                  QDMI_Operation_Property prop,
+                                  const size_t size, void *value,
+                                  size_t *size_ret) {
   return device->query_operation_property(operation, num_sites, sites, prop,
                                           size, value, size_ret);
 }
 
 int QDMI_control_create_job(QDMI_Device dev, QDMI_Program_Format format,
-                            const int size, const void *prog, QDMI_Job *job) {
+                            const size_t size, const void *prog,
+                            QDMI_Job *job) {
   if ((dev->mode & QDMI_DEVICE_MODE_READWRITE) != 0) {
     return dev->control_create_job(format, size, prog, job);
   }
@@ -326,7 +331,7 @@ int QDMI_control_create_job(QDMI_Device dev, QDMI_Program_Format format,
 }
 
 int QDMI_control_set_parameter(QDMI_Device dev, QDMI_Job job,
-                               QDMI_Job_Parameter param, const int size,
+                               QDMI_Job_Parameter param, const size_t size,
                                const void *value) {
   if ((dev->mode & QDMI_DEVICE_MODE_READWRITE) != 0) {
     return dev->control_set_parameter(job, param, size, value);
@@ -363,7 +368,7 @@ int QDMI_control_wait(QDMI_Device dev, QDMI_Job job) {
 }
 
 int QDMI_control_get_data(QDMI_Device dev, QDMI_Job job, QDMI_Job_Result result,
-                          const int size, void *data, int *size_ret) {
+                          const size_t size, void *data, size_t *size_ret) {
   if ((dev->mode & QDMI_DEVICE_MODE_READWRITE) != 0) {
     return dev->control_get_data(job, result, size, data, size_ret);
   }

--- a/examples/fomac/example_fomac.cpp
+++ b/examples/fomac/example_fomac.cpp
@@ -89,17 +89,17 @@ auto FoMaC::throw_if_error(int status, const std::string &message) -> void {
   }
 }
 
-auto FoMaC::get_qubits_num() const -> int {
-  int num_qubits = 0;
+auto FoMaC::get_qubits_num() const -> size_t {
+  size_t num_qubits = 0;
   const int ret =
       QDMI_query_device_property(device, QDMI_DEVICE_PROPERTY_QUBITSNUM,
-                                 sizeof(int), &num_qubits, nullptr);
+                                 sizeof(size_t), &num_qubits, nullptr);
   throw_if_error(ret, "Failed to query the number of qubits.");
   return num_qubits;
 }
 
 auto FoMaC::get_operation_map() const -> std::map<std::string, QDMI_Operation> {
-  int ops_num = 0;
+  size_t ops_num = 0;
   int ret = QDMI_query_get_operations(device, 0, nullptr, &ops_num);
   throw_if_error(ret, "Failed to retrieve operation number.");
   std::vector<QDMI_Operation> ops(ops_num);
@@ -107,7 +107,7 @@ auto FoMaC::get_operation_map() const -> std::map<std::string, QDMI_Operation> {
   throw_if_error(ret, "Failed to retrieve operations.");
   std::map<std::string, QDMI_Operation> ops_map;
   for (const auto &op : ops) {
-    int name_length = 0;
+    size_t name_length = 0;
     ret = QDMI_query_operation_property(device, op, 0, nullptr,
                                         QDMI_OPERATION_PROPERTY_NAME, 0,
                                         nullptr, &name_length);
@@ -124,13 +124,12 @@ auto FoMaC::get_operation_map() const -> std::map<std::string, QDMI_Operation> {
 
 auto FoMaC::get_coupling_map() const
     -> std::vector<std::pair<QDMI_Site, QDMI_Site>> {
-  int size = 0;
+  size_t size = 0;
   int ret = QDMI_query_device_property(device, QDMI_DEVICE_PROPERTY_COUPLINGMAP,
                                        0, nullptr, &size);
   throw_if_error(ret, "Failed to query the coupling map size.");
 
-  const auto coupling_map_size =
-      static_cast<std::size_t>(size) / sizeof(QDMI_Site);
+  const auto coupling_map_size = size / sizeof(QDMI_Site);
   if (coupling_map_size % 2 != 0) {
     throw std::runtime_error("The coupling map needs to have an even number of "
                              "elements.");
@@ -147,19 +146,19 @@ auto FoMaC::get_coupling_map() const
 }
 
 auto FoMaC::get_sites() const -> std::vector<QDMI_Site> {
-  int sites_num = 0;
+  size_t sites_num = 0;
   int ret = QDMI_query_get_sites(device, 0, nullptr, &sites_num);
   throw_if_error(ret, "Failed to get the sites number.");
-  std::vector<QDMI_Site> sites(static_cast<std::size_t>(sites_num));
+  std::vector<QDMI_Site> sites(sites_num);
   ret = QDMI_query_get_sites(device, sites_num, sites.data(), nullptr);
   throw_if_error(ret, "Failed to get the sites.");
   return sites;
 }
 
-int FoMaC::get_operands_num(const QDMI_Operation &op) const {
-  int operands_num = 0;
+auto FoMaC::get_operands_num(const QDMI_Operation &op) const -> size_t {
+  size_t operands_num = 0;
   const int ret = QDMI_query_operation_property(
-      device, op, 0, nullptr, QDMI_OPERATION_PROPERTY_QUBITSNUM, sizeof(int),
+      device, op, 0, nullptr, QDMI_OPERATION_PROPERTY_QUBITSNUM, sizeof(size_t),
       &operands_num, nullptr);
   throw_if_error(ret, "Failed to query the operand number");
   return operands_num;

--- a/examples/fomac/example_fomac.hpp
+++ b/examples/fomac/example_fomac.hpp
@@ -15,6 +15,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "qdmi/client.h"
 
 #include <cassert>
+#include <cstddef>
 #include <map>
 #include <string>
 #include <utility>
@@ -29,7 +30,7 @@ private:
 public:
   explicit FoMaC(QDMI_Device dev) : device(dev) {}
 
-  [[nodiscard]] auto get_qubits_num() const -> int;
+  [[nodiscard]] auto get_qubits_num() const -> size_t;
 
   [[nodiscard]] auto get_operation_map() const
       -> std::map<std::string, QDMI_Operation>;
@@ -39,5 +40,5 @@ public:
   [[nodiscard]] auto get_coupling_map() const
       -> std::vector<std::pair<QDMI_Site, QDMI_Site>>;
 
-  [[nodiscard]] auto get_operands_num(const QDMI_Operation &op) const -> int;
+  [[nodiscard]] auto get_operands_num(const QDMI_Operation &op) const -> size_t;
 };

--- a/examples/tool/example_tool.cpp
+++ b/examples/tool/example_tool.cpp
@@ -45,7 +45,7 @@ std::string Tool::compile(const std::string &qasm_string) {
   }
   const std::smatch &match = *begin;
   const auto num_qubits_str = match.str(1);
-  const auto num_qubits = std::stoi(num_qubits_str);
+  const auto num_qubits = std::stoul(num_qubits_str);
   if (num_qubits > 2) {
     throw std::invalid_argument("The circuit uses more than two qubits but "
                                 "this tool only supports up to two qubits.");

--- a/include/qdmi/client/control.h
+++ b/include/qdmi/client/control.h
@@ -16,7 +16,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "qdmi/common/types.h"
 
 #ifdef __cplusplus
+#include <cstddef>
+
 extern "C" {
+#else
+#include <stddef.h>
 #endif
 
 /**
@@ -33,14 +37,14 @@ extern "C" {
  * @param[in] prog is the program to run.
  * @param[out] job is a handle to the job created.
  * @return @ref QDMI_SUCCESS if the job was successfully created.
- * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p size is less than or equal to
- * zero or the program @p prog is invalid, e.g. @c NULL.
+ * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p size is zero or the program
+ * @p prog is invalid, e.g. @c NULL.
  * @return @ref QDMI_ERROR_NOTSUPPORTED if the device does not support the
  * program format.
  * @return @ref QDMI_ERROR_FATAL if the job creation failed.
  */
 int QDMI_control_create_job(QDMI_Device dev, QDMI_Program_Format format,
-                            int size, const void *prog, QDMI_Job *job);
+                            size_t size, const void *prog, QDMI_Job *job);
 
 /**
  * @brief Set a parameter for a job.
@@ -60,7 +64,7 @@ int QDMI_control_create_job(QDMI_Device dev, QDMI_Program_Format format,
  * @return @ref QDMI_ERROR_FATAL if the parameter could not be set.
  */
 int QDMI_control_set_parameter(QDMI_Device dev, QDMI_Job job,
-                               QDMI_Job_Parameter param, int size,
+                               QDMI_Job_Parameter param, size_t size,
                                const void *value);
 
 /**
@@ -135,7 +139,7 @@ int QDMI_control_wait(QDMI_Device dev, QDMI_Job job);
  * @return @ref QDMI_ERROR_FATAL if an error occurred during the retrieval.
  */
 int QDMI_control_get_data(QDMI_Device dev, QDMI_Job job, QDMI_Job_Result result,
-                          int size, void *data, int *size_ret);
+                          size_t size, void *data, size_t *size_ret);
 
 /**
  * @brief Free a job.

--- a/include/qdmi/client/query.h
+++ b/include/qdmi/client/query.h
@@ -13,7 +13,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "qdmi/common/types.h"
 
 #ifdef __cplusplus
+#include <cstddef>
+
 extern "C" {
+#else
+#include <stddef.h>
 #endif
 
 /**
@@ -33,12 +37,12 @@ extern "C" {
  * @return @ref QDMI_SUCCESS if the function is executed successfully.
  * Otherwise, it returns one of the following error codes:
  * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p device is an invalid device,
- * if @p num_entries is less than or equal to zero and @p sites is not @c NULL
- * or if both @p sites and @p num_sites are @c NULL.
+ * if @p num_entries is zero and @p sites is not @c NULL or if both @p sites and
+ * @p num_sites are @c NULL.
  * @return @ref QDMI_ERROR_FATAL if an unexpected error occurred.
  */
-int QDMI_query_get_sites(QDMI_Device device, int num_entries, QDMI_Site *sites,
-                         int *num_sites);
+int QDMI_query_get_sites(QDMI_Device device, size_t num_entries,
+                         QDMI_Site *sites, size_t *num_sites);
 
 /**
  * @brief Get the operations available on the @p device.
@@ -59,13 +63,13 @@ int QDMI_query_get_sites(QDMI_Device device, int num_entries, QDMI_Site *sites,
  * @return @ref QDMI_SUCCESS if the function is executed successfully.
  * Otherwise, it returns one of the following error codes:
  * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p device is an invalid device,
- * if @p num_entries is less than or equal to zero and @p operations is not @c
- * NULL or if both @p operations and
- * @p num_operations are @c NULL.
+ * if @p num_entries is zero and @p operations is not @c NULL or if both
+ * @p operations and @p num_operations are @c NULL.
  * @return @ref QDMI_ERROR_FATAL if an unexpected error occurred.
  */
-int QDMI_query_get_operations(QDMI_Device device, int num_entries,
-                              QDMI_Operation *operations, int *num_operations);
+int QDMI_query_get_operations(QDMI_Device device, size_t num_entries,
+                              QDMI_Operation *operations,
+                              size_t *num_operations);
 
 /**
  * @brief Query a device property.
@@ -100,7 +104,7 @@ int QDMI_query_get_operations(QDMI_Device device, int num_entries,
  * @return @ref QDMI_ERROR_FATAL if an unexpected error occurred.
  */
 int QDMI_query_device_property(QDMI_Device device, QDMI_Device_Property prop,
-                               int size, void *value, int *size_ret);
+                               size_t size, void *value, size_t *size_ret);
 
 /**
  * @brief Query a site property.
@@ -148,8 +152,8 @@ int QDMI_query_device_property(QDMI_Device device, QDMI_Device_Property prop,
  * @return @ref QDMI_ERROR_FATAL if an unexpected error occurred.
  */
 int QDMI_query_site_property(QDMI_Device device, QDMI_Site site,
-                             QDMI_Site_Property prop, int size, void *value,
-                             int *size_ret);
+                             QDMI_Site_Property prop, size_t size, void *value,
+                             size_t *size_ret);
 
 /**
  * @brief Query an operation property.
@@ -189,9 +193,9 @@ int QDMI_query_site_property(QDMI_Device device, QDMI_Site site,
  * @return @ref QDMI_SUCCESS if the function is executed successfully.
  * Otherwise, it returns one of the following error codes:
  * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p device is an invalid device,
- * if @p num_sites is less than or equal to zero and @p sites is not @c NULL, if
- * @p prop is not one of the defined values, if the size in bytes specified by
- * @p size is less than the size of the data being queried as specified for the
+ * if @p num_sites is zero and @p sites is not @c NULL, if @p prop is not one of
+ * the defined values, if the size in bytes specified by @p size is less than
+ * the size of the data being queried as specified for the
  * @ref QDMI_Site_Property @p prop and @p value is not a @c NULL value, or if
  * both @p value and @p size_ret are @c NULL.
  * @return @ref QDMI_ERROR_NOTSUPPORTED if the property is not supported by the
@@ -199,9 +203,9 @@ int QDMI_query_site_property(QDMI_Device device, QDMI_Site site,
  * @return @ref QDMI_ERROR_FATAL if an unexpected error occurred.
  */
 int QDMI_query_operation_property(QDMI_Device device, QDMI_Operation operation,
-                                  int num_sites, const QDMI_Site *sites,
-                                  QDMI_Operation_Property prop, int size,
-                                  void *value, int *size_ret);
+                                  size_t num_sites, const QDMI_Site *sites,
+                                  QDMI_Operation_Property prop, size_t size,
+                                  void *value, size_t *size_ret);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/qdmi/common/enums.h
+++ b/include/qdmi/common/enums.h
@@ -14,6 +14,10 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 extern "C" {
 #endif
 
+// The following clang-tidy warning cannot be addressed because this header is
+// used from both C and C++ code.
+// NOLINTBEGIN(performance-enum-size)
+
 /// Enum of the device properties that can be queried.
 enum QDMI_DEVICE_PROPERTY_T {
   QDMI_DEVICE_PROPERTY_NAME, ///< `char*` (string) The name of the device.
@@ -290,6 +294,8 @@ enum QDMI_JOB_RESULT_T {
    */
   QDMI_JOB_RESULT_MAX
 };
+
+// NOLINTEND(performance-enum-size)
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/qdmi/common/enums.h
+++ b/include/qdmi/common/enums.h
@@ -23,7 +23,7 @@ enum QDMI_DEVICE_PROPERTY_T {
   QDMI_DEVICE_PROPERTY_STATUS,
   /// `char*` (string) The implemented version of QDMI.
   QDMI_DEVICE_PROPERTY_LIBRARYVERSION,
-  /// `int` The number of qubits in the device.
+  /// `size_t` The number of qubits in the device.
   QDMI_DEVICE_PROPERTY_QUBITSNUM,
   /**
    * @brief `int*` (int list) The coupling map of the device.
@@ -106,7 +106,7 @@ enum QDMI_SITE_PROPERTY_T {
 enum QDMI_OPERATION_PROPERTY_T {
   /// `char*` (string) The string identifier of the operation.
   QDMI_OPERATION_PROPERTY_NAME,
-  /// `int` The number of qubits in the operation.
+  /// `size_t` The number of qubits in the operation.
   QDMI_OPERATION_PROPERTY_QUBITSNUM,
   /// `double` The duration of an operation in µs.
   QDMI_OPERATION_PROPERTY_DURATION,
@@ -189,7 +189,7 @@ enum QDMI_PROGRAM_FORMAT_T {
   QDMI_PROGRAM_FORMAT_QASM3,
   /// `char*`(string) The QIR program to run as a string.
   QDMI_PROGRAM_FORMAT_QIRSTRING,
-  /// `char*`(string) The QIR program as a binary module.
+  /// `void*` The QIR program as a binary module.
   QDMI_PROGRAM_FORMAT_QIRMODULE,
   /**
    * @brief This value is reserved for a custom format.
@@ -217,7 +217,7 @@ enum QDMI_PROGRAM_FORMAT_T {
  * @brief Enum of the job parameters that can be set.
  */
 enum QDMI_JOB_PARAMETER_T {
-  /// `int` The number of shots to take.
+  /// `size_t` The number of shots to take.
   QDMI_JOB_PARAMETER_SHOTS_NUM,
   /**
    * @brief This property is reserved for a custom property.
@@ -264,7 +264,7 @@ enum QDMI_JOB_RESULT_T {
    */
   QDMI_JOB_RESULT_HIST_KEYS,
   /**
-   * @brief `int*` (int list) The values for the histogram of the results.
+   * @brief `size_t*` (int list) The values for the histogram of the results.
    * @see QDMI_JOB_RESULT_HIST_KEY
    */
   QDMI_JOB_RESULT_HIST_VALUES,

--- a/include/qdmi/device/control.h
+++ b/include/qdmi/device/control.h
@@ -13,7 +13,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "qdmi/common/types.h"
 
 #ifdef __cplusplus
+#include <cstddef>
+
 extern "C" {
+#else
+#include <stddef.h>
 #endif
 
 /**
@@ -35,7 +39,7 @@ extern "C" {
  * program format.
  * @return @ref QDMI_ERROR_FATAL if the job creation failed.
  */
-int QDMI_control_create_job_dev(QDMI_Program_Format format, int size,
+int QDMI_control_create_job_dev(QDMI_Program_Format format, size_t size,
                                 const void *prog, QDMI_Job *job);
 
 /**
@@ -55,7 +59,7 @@ int QDMI_control_create_job_dev(QDMI_Program_Format format, int size,
  * @return @ref QDMI_ERROR_FATAL if the parameter could not be set.
  */
 int QDMI_control_set_parameter_dev(QDMI_Job job, QDMI_Job_Parameter param,
-                                   int size, const void *value);
+                                   size_t size, const void *value);
 
 /**
  * @brief Submit a job to the device.
@@ -123,8 +127,8 @@ int QDMI_control_wait_dev(QDMI_Job job);
  * cancelled, or does not exist.
  * @return @ref QDMI_ERROR_FATAL if an error occurred during the retrieval.
  */
-int QDMI_control_get_data_dev(QDMI_Job job, QDMI_Job_Result result, int size,
-                              void *data, int *size_ret);
+int QDMI_control_get_data_dev(QDMI_Job job, QDMI_Job_Result result, size_t size,
+                              void *data, size_t *size_ret);
 
 /**
  * @brief Free a job.

--- a/include/qdmi/device/query.h
+++ b/include/qdmi/device/query.h
@@ -13,7 +13,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "qdmi/common/types.h"
 
 #ifdef __cplusplus
+#include <cstddef>
+
 extern "C" {
+#else
+#include <stddef.h>
 #endif
 
 /**
@@ -29,12 +33,12 @@ extern "C" {
  * is @c NULL, this argument is ignored.
  * @return @ref QDMI_SUCCESS if the function is executed successfully.
  * Otherwise, it returns one of the following error codes:
- * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p num_entries is less than or
- * equal to zero and @p sites is not @c NULL or if both @p sites and @p
- * num_sites are @c NULL.
+ * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p num_entries is zero and
+ * @p sites is not @c NULL or if both @p sites and @p num_sites are @c NULL.
  * @return @ref QDMI_ERROR_FATAL if an unexpected error occurred.
  */
-int QDMI_query_get_sites_dev(int num_entries, QDMI_Site *sites, int *num_sites);
+int QDMI_query_get_sites_dev(size_t num_entries, QDMI_Site *sites,
+                             size_t *num_sites);
 
 /**
  * @brief Get the operations available on the @p device.
@@ -51,13 +55,14 @@ int QDMI_query_get_sites_dev(int num_entries, QDMI_Site *sites, int *num_sites);
  * num_operations is @c NULL, this argument is ignored.
  * @return @ref QDMI_SUCCESS if the function is executed successfully.
  * Otherwise, it returns one of the following error codes:
- * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p num_entries is less than or
- * equal to zero and @p operations is not @c NULL or if both @p operations and
- * @p num_operations are @c NULL.
+ * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p num_entries is zero and
+ * @p operations is not @c NULL or if both @p operations and @p num_operations
+ * are @c NULL.
  * @return @ref QDMI_ERROR_FATAL if an unexpected error occurred.
  */
-int QDMI_query_get_operations_dev(int num_entries, QDMI_Operation *operations,
-                                  int *num_operations);
+int QDMI_query_get_operations_dev(size_t num_entries,
+                                  QDMI_Operation *operations,
+                                  size_t *num_operations);
 
 /**
  * @brief Query a device property.
@@ -88,8 +93,8 @@ int QDMI_query_get_operations_dev(int num_entries, QDMI_Operation *operations,
  * device.
  * @return @ref QDMI_ERROR_FATAL if an unexpected error occurred.
  */
-int QDMI_query_device_property_dev(QDMI_Device_Property prop, int size,
-                                   void *value, int *size_ret);
+int QDMI_query_device_property_dev(QDMI_Device_Property prop, size_t size,
+                                   void *value, size_t *size_ret);
 
 /**
  * @brief Query a site property.
@@ -122,7 +127,7 @@ int QDMI_query_device_property_dev(QDMI_Device_Property prop, int size,
  * @return @ref QDMI_ERROR_FATAL if an unexpected error occurred.
  */
 int QDMI_query_site_property_dev(QDMI_Site site, QDMI_Site_Property prop,
-                                 int size, void *value, int *size_ret);
+                                 size_t size, void *value, size_t *size_ret);
 
 /**
  * @brief Query an operation property.
@@ -159,20 +164,19 @@ int QDMI_query_site_property_dev(QDMI_Site site, QDMI_Site_Property prop,
  * @return @ref QDMI_SUCCESS if the function is executed successfully.
  * Otherwise, it returns one of the following error codes:
  * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p operation is an invalid
- * operation, if @p num_sites is less than or equal to zero and @p sites is not
- * @c NULL, if
- * @p prop is not one of the defined values, if the size in bytes specified by
- * @p size is less than the size of the data being queried as specified for the
+ * operation, if @p num_sites is zero and @p sites is not @c NULL, if @p prop is
+ * not one of the defined values, if the size in bytes specified by @p size is
+ * less than the size of the data being queried as specified for the
  * @ref QDMI_Site_Property @p prop and @p value is not a @c NULL value, or if
  * both @p value and @p size_ret are @c NULL.
  * @return @ref QDMI_ERROR_NOTSUPPORTED if the property is not supported by the
  * device or for the given list of sites.
  * @return @ref QDMI_ERROR_FATAL if an unexpected error occurred.
  */
-int QDMI_query_operation_property_dev(QDMI_Operation operation, int num_sites,
-                                      const QDMI_Site *sites,
-                                      QDMI_Operation_Property prop, int size,
-                                      void *value, int *size_ret);
+int QDMI_query_operation_property_dev(QDMI_Operation operation,
+                                      size_t num_sites, const QDMI_Site *sites,
+                                      QDMI_Operation_Property prop, size_t size,
+                                      void *value, size_t *size_ret);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/qdmi/driver/session.h
+++ b/include/qdmi/driver/session.h
@@ -18,7 +18,11 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "qdmi/common/types.h"
 
 #ifdef __cplusplus
+#include <cstddef>
+
 extern "C" {
+#else
+#include <stddef.h>
 #endif
 
 /**
@@ -49,13 +53,12 @@ int QDMI_session_alloc(QDMI_Session *session);
  * num_devices is `NULL`, this argument is ignored.
  * @return @ref QDMI_SUCCESS if the function is executed successfully.
  * Otherwise, it returns one of the following error codes:
- * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p num_entries is less than or
- * equal to zero and @p devices is not `NULL` or if both @p devices and @p
- * num_devices are `NULL`.
+ * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p num_entries is zero and
+ * @p devices is not `NULL` or if both @p devices and @p num_devices are `NULL`.
  * @return @ref QDMI_ERROR_FATAL if an unexpected error occurred.
  */
-int QDMI_session_get_devices(QDMI_Session session, int num_entries,
-                             QDMI_Device *devices, int *num_devices);
+int QDMI_session_get_devices(QDMI_Session session, size_t num_entries,
+                             QDMI_Device *devices, size_t *num_devices);
 
 /**
  * @brief Free a QDMI session.

--- a/templates/device/src/my_device.cpp
+++ b/templates/device/src/my_device.cpp
@@ -13,6 +13,12 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "qdmi/device.h"
 
+#ifdef __cplusplus
+#include <cstddef>
+#else
+#include <stddef.h>
+#endif
+
 // The following line ignores the unused parameters in the functions.
 // Please remove the following code block after populating the functions.
 // NOLINTBEGIN(misc-unused-parameters,clang-diagnostic-unused-parameter)
@@ -41,40 +47,41 @@ struct QDMI_Site_impl_d {};
  */
 struct QDMI_Operation_impl_d {};
 
-int QDMI_query_get_sites_dev(int num_entries, QDMI_Site *sites,
-                             int *num_sites) {
+int QDMI_query_get_sites_dev(size_t num_entries, QDMI_Site *sites,
+                             size_t *num_sites) {
   return QDMI_ERROR_NOTIMPLEMENTED;
 }
 
-int QDMI_query_get_operations_dev(int num_entries, QDMI_Operation *operations,
-                                  int *num_operations) {
+int QDMI_query_get_operations_dev(size_t num_entries,
+                                  QDMI_Operation *operations,
+                                  size_t *num_operations) {
   return QDMI_ERROR_NOTIMPLEMENTED;
 }
 
-int QDMI_query_device_property_dev(QDMI_Device_Property prop, int size,
-                                   void *value, int *size_ret) {
+int QDMI_query_device_property_dev(QDMI_Device_Property prop, size_t size,
+                                   void *value, size_t *size_ret) {
   return QDMI_ERROR_NOTIMPLEMENTED;
 }
 
 int QDMI_query_site_property_dev(QDMI_Site site, QDMI_Site_Property prop,
-                                 int size, void *value, int *size_ret) {
+                                 size_t size, void *value, size_t *size_ret) {
   return QDMI_ERROR_NOTIMPLEMENTED;
 }
 
-int QDMI_query_operation_property_dev(QDMI_Operation operation, int num_sites,
-                                      const QDMI_Site *sites,
-                                      QDMI_Operation_Property prop, int size,
-                                      void *value, int *size_ret) {
+int QDMI_query_operation_property_dev(QDMI_Operation operation,
+                                      size_t num_sites, const QDMI_Site *sites,
+                                      QDMI_Operation_Property prop, size_t size,
+                                      void *value, size_t *size_ret) {
   return QDMI_ERROR_NOTIMPLEMENTED;
 }
 
-int QDMI_control_create_job_dev(QDMI_Program_Format format, int size,
+int QDMI_control_create_job_dev(QDMI_Program_Format format, size_t size,
                                 const void *prog, QDMI_Job *job) {
   return QDMI_ERROR_NOTIMPLEMENTED;
 }
 
 int QDMI_control_set_parameter_dev(QDMI_Job job, QDMI_Job_Parameter param,
-                                   int size, const void *value) {
+                                   size_t size, const void *value) {
   return QDMI_ERROR_NOTIMPLEMENTED;
 }
 
@@ -90,8 +97,8 @@ int QDMI_control_check_dev(QDMI_Job job, QDMI_Job_Status *status) {
 
 int QDMI_control_wait_dev(QDMI_Job job) { return QDMI_ERROR_NOTIMPLEMENTED; }
 
-int QDMI_control_get_data_dev(QDMI_Job job, QDMI_Job_Result result, int size,
-                              void *data, int *size_ret) {
+int QDMI_control_get_data_dev(QDMI_Job job, QDMI_Job_Result result, size_t size,
+                              void *data, size_t *size_ret) {
   return QDMI_ERROR_NOTIMPLEMENTED;
 }
 

--- a/templates/device/test/test_my_device.cpp
+++ b/templates/device/test/test_my_device.cpp
@@ -63,20 +63,18 @@ std::string Get_test_circuit() {
 
 TEST_F(QDMIImplementationTest, ControlCreateJobImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_NE(QDMI_control_create_job_dev(
-                QDMI_PROGRAM_FORMAT_QASM2,
-                static_cast<int>(Get_test_circuit().length() + 1),
-                Get_test_circuit().c_str(), &job),
+  ASSERT_NE(QDMI_control_create_job_dev(QDMI_PROGRAM_FORMAT_QASM2,
+                                        Get_test_circuit().length() + 1,
+                                        Get_test_circuit().c_str(), &job),
             QDMI_ERROR_NOTIMPLEMENTED);
   QDMI_control_free_job_dev(job);
 }
 
 TEST_F(QDMIImplementationTest, ControlSetParameterImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_EQ(QDMI_control_create_job_dev(
-                QDMI_PROGRAM_FORMAT_QASM2,
-                static_cast<int>(Get_test_circuit().length() + 1),
-                Get_test_circuit().c_str(), &job),
+  ASSERT_EQ(QDMI_control_create_job_dev(QDMI_PROGRAM_FORMAT_QASM2,
+                                        Get_test_circuit().length() + 1,
+                                        Get_test_circuit().c_str(), &job),
             QDMI_SUCCESS);
   ASSERT_EQ(
       QDMI_control_set_parameter_dev(job, QDMI_JOB_PARAMETER_MAX, 0, nullptr),
@@ -86,10 +84,9 @@ TEST_F(QDMIImplementationTest, ControlSetParameterImplemented) {
 
 TEST_F(QDMIImplementationTest, ControlSubmitJobImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_EQ(QDMI_control_create_job_dev(
-                QDMI_PROGRAM_FORMAT_QASM2,
-                static_cast<int>(Get_test_circuit().length() + 1),
-                Get_test_circuit().c_str(), &job),
+  ASSERT_EQ(QDMI_control_create_job_dev(QDMI_PROGRAM_FORMAT_QASM2,
+                                        Get_test_circuit().length() + 1,
+                                        Get_test_circuit().c_str(), &job),
             QDMI_SUCCESS);
   ASSERT_NE(QDMI_control_submit_job_dev(job), QDMI_ERROR_NOTIMPLEMENTED);
   QDMI_control_free_job_dev(job);
@@ -97,10 +94,9 @@ TEST_F(QDMIImplementationTest, ControlSubmitJobImplemented) {
 
 TEST_F(QDMIImplementationTest, ControlCancelImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_EQ(QDMI_control_create_job_dev(
-                QDMI_PROGRAM_FORMAT_QASM2,
-                static_cast<int>(Get_test_circuit().length() + 1),
-                Get_test_circuit().c_str(), &job),
+  ASSERT_EQ(QDMI_control_create_job_dev(QDMI_PROGRAM_FORMAT_QASM2,
+                                        Get_test_circuit().length() + 1,
+                                        Get_test_circuit().c_str(), &job),
             QDMI_SUCCESS);
   ASSERT_NE(QDMI_control_cancel_dev(job), QDMI_ERROR_NOTIMPLEMENTED);
   QDMI_control_free_job_dev(job);
@@ -109,10 +105,9 @@ TEST_F(QDMIImplementationTest, ControlCancelImplemented) {
 TEST_F(QDMIImplementationTest, ControlCheckImplemented) {
   QDMI_Job job = nullptr;
   QDMI_Job_Status status = QDMI_JOB_STATUS_RUNNING;
-  ASSERT_EQ(QDMI_control_create_job_dev(
-                QDMI_PROGRAM_FORMAT_QASM2,
-                static_cast<int>(Get_test_circuit().length() + 1),
-                Get_test_circuit().c_str(), &job),
+  ASSERT_EQ(QDMI_control_create_job_dev(QDMI_PROGRAM_FORMAT_QASM2,
+                                        Get_test_circuit().length() + 1,
+                                        Get_test_circuit().c_str(), &job),
             QDMI_SUCCESS);
   ASSERT_NE(QDMI_control_check_dev(job, &status), QDMI_ERROR_NOTIMPLEMENTED);
   QDMI_control_free_job_dev(job);
@@ -120,10 +115,9 @@ TEST_F(QDMIImplementationTest, ControlCheckImplemented) {
 
 TEST_F(QDMIImplementationTest, ControlWaitImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_EQ(QDMI_control_create_job_dev(
-                QDMI_PROGRAM_FORMAT_QASM2,
-                static_cast<int>(Get_test_circuit().length() + 1),
-                Get_test_circuit().c_str(), &job),
+  ASSERT_EQ(QDMI_control_create_job_dev(QDMI_PROGRAM_FORMAT_QASM2,
+                                        Get_test_circuit().length() + 1,
+                                        Get_test_circuit().c_str(), &job),
             QDMI_SUCCESS);
   ASSERT_NE(QDMI_control_wait_dev(job), QDMI_ERROR_NOTIMPLEMENTED);
   QDMI_control_free_job_dev(job);
@@ -131,10 +125,9 @@ TEST_F(QDMIImplementationTest, ControlWaitImplemented) {
 
 TEST_F(QDMIImplementationTest, ControlGetHistImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_EQ(QDMI_control_create_job_dev(
-                QDMI_PROGRAM_FORMAT_QASM2,
-                static_cast<int>(Get_test_circuit().length() + 1),
-                Get_test_circuit().c_str(), &job),
+  ASSERT_EQ(QDMI_control_create_job_dev(QDMI_PROGRAM_FORMAT_QASM2,
+                                        Get_test_circuit().length() + 1,
+                                        Get_test_circuit().c_str(), &job),
             QDMI_SUCCESS);
   ASSERT_EQ(
       QDMI_control_get_data_dev(job, QDMI_JOB_RESULT_MAX, 0, nullptr, nullptr),
@@ -143,12 +136,12 @@ TEST_F(QDMIImplementationTest, ControlGetHistImplemented) {
 }
 
 TEST_F(QDMIImplementationTest, QueryDeviceNameImplemented) {
-  int size = 0;
+  size_t size = 0;
   ASSERT_EQ(QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_NAME, 0,
                                            nullptr, &size),
             QDMI_SUCCESS)
       << "Devices must provide a name";
-  std::string value(static_cast<size_t>(size), '\0');
+  std::string value(size - 1, '\0');
   ASSERT_EQ(QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_NAME, size,
                                            value.data(), nullptr),
             QDMI_SUCCESS)
@@ -157,12 +150,12 @@ TEST_F(QDMIImplementationTest, QueryDeviceNameImplemented) {
 }
 
 TEST_F(QDMIImplementationTest, QueryDeviceVersionImplemented) {
-  int size = 0;
+  size_t size = 0;
   ASSERT_EQ(QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_VERSION, 0,
                                            nullptr, &size),
             QDMI_SUCCESS)
       << "Devices must provide a version";
-  std::string value(static_cast<size_t>(size), '\0');
+  std::string value(size - 1, '\0');
   ASSERT_EQ(QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_VERSION, size,
                                            value.data(), nullptr),
             QDMI_SUCCESS)
@@ -171,12 +164,12 @@ TEST_F(QDMIImplementationTest, QueryDeviceVersionImplemented) {
 }
 
 TEST_F(QDMIImplementationTest, QueryDeviceLibraryVersionImplemented) {
-  int size = 0;
+  size_t size = 0;
   ASSERT_EQ(QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_LIBRARYVERSION,
                                            0, nullptr, &size),
             QDMI_SUCCESS)
       << "Devices must provide a library version";
-  std::string value(static_cast<size_t>(size), '\0');
+  std::string value(size - 1, '\0');
   ASSERT_EQ(QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_LIBRARYVERSION,
                                            size, value.data(), nullptr),
             QDMI_SUCCESS)
@@ -185,8 +178,9 @@ TEST_F(QDMIImplementationTest, QueryDeviceLibraryVersionImplemented) {
 }
 
 TEST_F(QDMIImplementationTest, QubitNum) {
-  int num_qubits = 0;
+  size_t num_qubits = 0;
   EXPECT_EQ(QDMI_query_device_property_dev(QDMI_DEVICE_PROPERTY_QUBITSNUM,
-                                           sizeof(int), &num_qubits, nullptr),
+                                           sizeof(size_t), &num_qubits,
+                                           nullptr),
             QDMI_SUCCESS);
 }

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -101,17 +101,17 @@ TEST_P(QDMIImplementationTest, QueryGatePropertiesForEachGate) {
     if (gate_num_qubits == 2) {
       for (const auto &[control, target] : coupling_map) {
         auto site_arr = std::array{control, target};
-        EXPECT_EQ(QDMI_query_operation_property(
-                      device, op, 2, site_arr.data(),
-                      QDMI_OPERATION_PROPERTY_DURATION, sizeof(double) * 2,
-                      &duration, nullptr),
-                  QDMI_SUCCESS)
+        EXPECT_EQ(
+            QDMI_query_operation_property(device, op, 2, site_arr.data(),
+                                          QDMI_OPERATION_PROPERTY_DURATION,
+                                          sizeof(double), &duration, nullptr),
+            QDMI_SUCCESS)
             << "Failed to query duration for gate " << op;
-        EXPECT_EQ(QDMI_query_operation_property(
-                      device, op, 2, site_arr.data(),
-                      QDMI_OPERATION_PROPERTY_FIDELITY, sizeof(double) * 2,
-                      &fidelity, nullptr),
-                  QDMI_SUCCESS)
+        EXPECT_EQ(
+            QDMI_query_operation_property(device, op, 2, site_arr.data(),
+                                          QDMI_OPERATION_PROPERTY_FIDELITY,
+                                          sizeof(double), &fidelity, nullptr),
+            QDMI_SUCCESS)
             << "Failed to query fidelity for gate " << op;
       }
     }

--- a/test/utils/test_impl.cpp
+++ b/test/utils/test_impl.cpp
@@ -104,21 +104,19 @@ std::string Get_test_circuit() {
 
 TEST_P(QDMIImplementationTest, ControlCreateJobImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_NE(
-      QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
-                              static_cast<int>(Get_test_circuit().length() + 1),
-                              Get_test_circuit().c_str(), &job),
-      QDMI_ERROR_NOTIMPLEMENTED);
+  ASSERT_NE(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    Get_test_circuit().length() + 1,
+                                    Get_test_circuit().c_str(), &job),
+            QDMI_ERROR_NOTIMPLEMENTED);
   QDMI_control_free_job(device, job);
 }
 
 TEST_P(QDMIImplementationTest, ControlSetParameterImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_EQ(
-      QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
-                              static_cast<int>(Get_test_circuit().length() + 1),
-                              Get_test_circuit().c_str(), &job),
-      QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    Get_test_circuit().length() + 1,
+                                    Get_test_circuit().c_str(), &job),
+            QDMI_SUCCESS);
   ASSERT_EQ(QDMI_control_set_parameter(device, job, QDMI_JOB_PARAMETER_MAX, 0,
                                        nullptr),
             QDMI_ERROR_INVALIDARGUMENT);
@@ -127,22 +125,20 @@ TEST_P(QDMIImplementationTest, ControlSetParameterImplemented) {
 
 TEST_P(QDMIImplementationTest, ControlSubmitJobImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_EQ(
-      QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
-                              static_cast<int>(Get_test_circuit().length() + 1),
-                              Get_test_circuit().c_str(), &job),
-      QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    Get_test_circuit().length() + 1,
+                                    Get_test_circuit().c_str(), &job),
+            QDMI_SUCCESS);
   ASSERT_NE(QDMI_control_submit_job(device, job), QDMI_ERROR_NOTIMPLEMENTED);
   QDMI_control_free_job(device, job);
 }
 
 TEST_P(QDMIImplementationTest, ControlCancelImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_EQ(
-      QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
-                              static_cast<int>(Get_test_circuit().length() + 1),
-                              Get_test_circuit().c_str(), &job),
-      QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    Get_test_circuit().length() + 1,
+                                    Get_test_circuit().c_str(), &job),
+            QDMI_SUCCESS);
   ASSERT_NE(QDMI_control_cancel(device, job), QDMI_ERROR_NOTIMPLEMENTED);
   QDMI_control_free_job(device, job);
 }
@@ -150,11 +146,10 @@ TEST_P(QDMIImplementationTest, ControlCancelImplemented) {
 TEST_P(QDMIImplementationTest, ControlCheckImplemented) {
   QDMI_Job job = nullptr;
   QDMI_Job_Status status = QDMI_JOB_STATUS_RUNNING;
-  ASSERT_EQ(
-      QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
-                              static_cast<int>(Get_test_circuit().length() + 1),
-                              Get_test_circuit().c_str(), &job),
-      QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    Get_test_circuit().length() + 1,
+                                    Get_test_circuit().c_str(), &job),
+            QDMI_SUCCESS);
   ASSERT_NE(QDMI_control_check(device, job, &status),
             QDMI_ERROR_NOTIMPLEMENTED);
   QDMI_control_free_job(device, job);
@@ -162,22 +157,20 @@ TEST_P(QDMIImplementationTest, ControlCheckImplemented) {
 
 TEST_P(QDMIImplementationTest, ControlWaitImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_EQ(
-      QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
-                              static_cast<int>(Get_test_circuit().length() + 1),
-                              Get_test_circuit().c_str(), &job),
-      QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    Get_test_circuit().length() + 1,
+                                    Get_test_circuit().c_str(), &job),
+            QDMI_SUCCESS);
   ASSERT_NE(QDMI_control_wait(device, job), QDMI_ERROR_NOTIMPLEMENTED);
   QDMI_control_free_job(device, job);
 }
 
 TEST_P(QDMIImplementationTest, ControlGetHistImplemented) {
   QDMI_Job job = nullptr;
-  ASSERT_EQ(
-      QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
-                              static_cast<int>(Get_test_circuit().length() + 1),
-                              Get_test_circuit().c_str(), &job),
-      QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    Get_test_circuit().length() + 1,
+                                    Get_test_circuit().c_str(), &job),
+            QDMI_SUCCESS);
   ASSERT_EQ(QDMI_control_get_data(device, job, QDMI_JOB_RESULT_MAX, 0, nullptr,
                                   nullptr),
             QDMI_ERROR_INVALIDARGUMENT);
@@ -185,12 +178,12 @@ TEST_P(QDMIImplementationTest, ControlGetHistImplemented) {
 }
 
 TEST_P(QDMIImplementationTest, QueryDeviceNameImplemented) {
-  int size = 0;
+  size_t size = 0;
   ASSERT_EQ(QDMI_query_device_property(device, QDMI_DEVICE_PROPERTY_NAME, 0,
                                        nullptr, &size),
             QDMI_SUCCESS)
       << "Devices must provide a name";
-  std::string value(static_cast<size_t>(size), '\0');
+  std::string value(size - 1, '\0');
   ASSERT_EQ(QDMI_query_device_property(device, QDMI_DEVICE_PROPERTY_NAME, size,
                                        value.data(), nullptr),
             QDMI_SUCCESS)
@@ -199,12 +192,12 @@ TEST_P(QDMIImplementationTest, QueryDeviceNameImplemented) {
 }
 
 TEST_P(QDMIImplementationTest, QueryDeviceVersionImplemented) {
-  int size = 0;
+  size_t size = 0;
   ASSERT_EQ(QDMI_query_device_property(device, QDMI_DEVICE_PROPERTY_VERSION, 0,
                                        nullptr, &size),
             QDMI_SUCCESS)
       << "Devices must provide a version";
-  std::string value(static_cast<size_t>(size), '\0');
+  std::string value(size - 1, '\0');
   ASSERT_EQ(QDMI_query_device_property(device, QDMI_DEVICE_PROPERTY_VERSION,
                                        size, value.data(), nullptr),
             QDMI_SUCCESS)
@@ -213,12 +206,12 @@ TEST_P(QDMIImplementationTest, QueryDeviceVersionImplemented) {
 }
 
 TEST_P(QDMIImplementationTest, QueryDeviceLibraryVersionImplemented) {
-  int size = 0;
+  size_t size = 0;
   ASSERT_EQ(QDMI_query_device_property(
                 device, QDMI_DEVICE_PROPERTY_LIBRARYVERSION, 0, nullptr, &size),
             QDMI_SUCCESS)
       << "Devices must provide a library version";
-  std::string value(static_cast<size_t>(size), '\0');
+  std::string value(size - 1, '\0');
   ASSERT_EQ(QDMI_query_device_property(device,
                                        QDMI_DEVICE_PROPERTY_LIBRARYVERSION,
                                        size, value.data(), nullptr),
@@ -236,11 +229,10 @@ TEST_P(QDMIImplementationTest, ControlDeviceModeReadOnly) {
   device = devices[1];
   ASSERT_NE(device, nullptr) << "Failed to get read-only device";
   QDMI_Job job{};
-  ASSERT_EQ(
-      QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
-                              static_cast<int>(Get_test_circuit().length() + 1),
-                              Get_test_circuit().c_str(), &job),
-      QDMI_ERROR_PERMISSIONDENIED);
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    Get_test_circuit().length() + 1,
+                                    Get_test_circuit().c_str(), &job),
+            QDMI_ERROR_PERMISSIONDENIED);
   ASSERT_EQ(QDMI_control_set_parameter(device, job, QDMI_JOB_PARAMETER_MAX, 0,
                                        nullptr),
             QDMI_ERROR_PERMISSIONDENIED);


### PR DESCRIPTION
Fixes #81

Replaces most occurrences of plain `int` with `size_t` throughout the interface and its example implementations.
This avoids quite a few casts due to different integer signedness and is a more natural choice for representing sizes and amounts.