### PR TITLE
📝 Remove not implemented functionality from comment

### DIFF
--- a/include/qdmi/driver/session.h
+++ b/include/qdmi/driver/session.h
@@ -7,8 +7,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 /** @file
  * @brief The QDMI session interface.
  * @details The driver manages resources provided to clients in sessions. This
- * header provides the interface for these sessions. It is also intended to
- * facilitate user management and access control.
+ * header provides the interface for these sessions.
  */
 
 #pragma once


### PR DESCRIPTION
Removes a sentence from the documentation that relates to a functionality that is not implemented yet.

Addresses #96.