### PR TITLE
Provision to set session parameters

### DIFF
--- a/examples/driver/qdmi_example_driver.cpp
+++ b/examples/driver/qdmi_example_driver.cpp
@@ -271,6 +271,8 @@ int QDMI_session_set_parameter(QDMI_Session session,
   case QDMI_SESSION_PARAMETER_TOKEN:
     session->token = std::string(static_cast<const char *>(value), size);
     return QDMI_SUCCESS;
+  default:
+    break;
   }
   return QDMI_ERROR_NOTSUPPORTED;
 }

--- a/examples/driver/qdmi_example_driver.cpp
+++ b/examples/driver/qdmi_example_driver.cpp
@@ -108,6 +108,8 @@ struct QDMI_Device_impl_d {
  */
 struct QDMI_Session_impl_d {
   std::vector<std::shared_ptr<QDMI_Device_impl_d>> device_list;
+  std::string owner;
+  std::string token;
 };
 
 /// @}
@@ -250,9 +252,27 @@ int QDMI_Driver_init() {
 
 int QDMI_session_alloc(QDMI_Session *session) {
   *session = new QDMI_Session_impl_d();
-  // in this simple implementation, each session has access to all devices
-  (*session)->device_list = device_list;
   return QDMI_SUCCESS;
+}
+
+int QDMI_session_set_parameter(QDMI_Session session,
+                               QDMI_Session_Parameter param, const size_t size,
+                               const void *value) {
+  // size == 0 and value == nullptr are allowed in case the client want to reset
+  // the parameter
+  if (session == nullptr || param >= QDMI_SESSION_PARAMETER_MAX) {
+    return QDMI_ERROR_INVALIDARGUMENT;
+  }
+
+  switch (param) {
+  case QDMI_SESSION_PARAMETER_OWNER:
+    session->owner = std::string(static_cast<const char *>(value), size);
+    return QDMI_SUCCESS;
+  case QDMI_SESSION_PARAMETER_TOKEN:
+    session->token = std::string(static_cast<const char *>(value), size);
+    return QDMI_SUCCESS;
+  }
+  return QDMI_ERROR_NOTSUPPORTED;
 }
 
 int QDMI_session_get_devices(QDMI_Session session, const size_t num_entries,
@@ -270,6 +290,16 @@ int QDMI_session_get_devices(QDMI_Session session, const size_t num_entries,
     }
     return QDMI_SUCCESS;
   }
+
+  // In this simple implementation, each session has access to all devices if an
+  // owner or token is provided. If the owner or token is not provided, the
+  // session has access to no devices and return QDMI_ERROR_PERMISSIONDENIED
+  if (session->owner.empty() && session->token.empty()) {
+    session->device_list.clear();
+    return QDMI_ERROR_PERMISSIONDENIED;
+  }
+
+  session->device_list = device_list;
 
   const auto num_devices_in_session = session->device_list.size();
   if (devices == nullptr) {

--- a/include/qdmi/common/enums.h
+++ b/include/qdmi/common/enums.h
@@ -363,6 +363,37 @@ enum QDMI_JOB_RESULT_T {
   QDMI_JOB_RESULT_MAX
 };
 
+/**
+ * @brief Enum of the session parameters that can be set.
+ */
+enum QDMI_SESSION_PARAMETER_T {
+  /// `char*` (string) The owner of the session.
+  QDMI_SESSION_PARAMETER_OWNER,
+  /// `char*` (string) The access token for the session.
+  QDMI_SESSION_PARAMETER_TOKEN,
+  /**
+   * @brief This property is reserved for a custom property.
+   * @details The meaning and the type of this property is defined by the
+   * driver.
+   */
+  QDMI_SESSION_PARAMETER_CUSTOM_1,
+  /// @see QDMI_SESSION_PARAMETER_CUSTOM_1
+  QDMI_SESSION_PARAMETER_CUSTOM_2,
+  /// @see QDMI_SESSION_PARAMETER_CUSTOM_1
+  QDMI_SESSION_PARAMETER_CUSTOM_3,
+  /// @see QDMI_SESSION_PARAMETER_CUSTOM_1
+  QDMI_SESSION_PARAMETER_CUSTOM_4,
+  /// @see QDMI_SESSION_PARAMETER_CUSTOM_1
+  QDMI_SESSION_PARAMETER_CUSTOM_5,
+  /**
+   * @brief The maximum value of the enum.
+   * @details This value can be used for bounds checks by the drivers.
+   * @note This value should always be updated to be the last and maximum value
+   * of the enum.
+   */
+  QDMI_SESSION_PARAMETER_MAX
+};
+
 // NOLINTEND(performance-enum-size)
 
 #ifdef __cplusplus

--- a/include/qdmi/common/types.h
+++ b/include/qdmi/common/types.h
@@ -59,6 +59,9 @@ typedef enum QDMI_JOB_PARAMETER_T QDMI_Job_Parameter;
 /// Type of the job result.
 typedef enum QDMI_JOB_RESULT_T QDMI_Job_Result;
 
+/// Type of the session parameter.
+typedef enum QDMI_SESSION_PARAMETER_T QDMI_Session_Parameter;
+
 // NOLINTEND(modernize-use-using)
 
 #ifdef __cplusplus

--- a/include/qdmi/driver/session.h
+++ b/include/qdmi/driver/session.h
@@ -24,6 +24,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #pragma once
 
+#include "qdmi/common/types.h"
 #include "qdmi/driver/types.h"
 
 #ifdef __cplusplus

--- a/include/qdmi/driver/session.h
+++ b/include/qdmi/driver/session.h
@@ -47,6 +47,24 @@ extern "C" {
 int QDMI_session_alloc(QDMI_Session *session);
 
 /**
+ * @brief Set a parameter for a session.
+ * @details This function sets a parameter for a session. The parameter can be
+ * one of the predefined parameters in @ref QDMI_Session_Parameter.
+ * @param[in] session refers to the session to set the parameter for.
+ * @param[in] param the parameter to set.
+ * @param[in] size the size of the value in bytes.
+ * @param[in] value the value to set the parameter to.
+ * @return @ref QDMI_SUCCESS if the parameter was set successfully.
+ * @return @ref QDMI_ERROR_INVALIDARGUMENT if the session does not exist, is in
+ * an invalid state or the parameter is invalid.
+ * @return @ref QDMI_ERROR_NOTSUPPORTED if the device does not support the
+ * parameter.
+ * @return @ref QDMI_ERROR_FATAL if the parameter could not be set.
+ */
+int QDMI_session_set_parameter(QDMI_Session session,
+                               QDMI_Session_Parameter param, size_t size,
+                               const void *value);
+/**
  * @brief Get the devices associated with @p session.
  * @param[in] session refers to the session returned by @ref QDMI_session_alloc
  * or can be `NULL`. If @p session is `NULL`, the behavior is

--- a/test/utils/test_impl.cpp
+++ b/test/utils/test_impl.cpp
@@ -64,6 +64,13 @@ void QDMIImplementationTest::SetUp() {
   ASSERT_EQ(QDMI_session_alloc(&session), QDMI_SUCCESS)
       << "Failed to allocate session";
 
+  std::string test_token = "test_token";
+  ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_TOKEN,
+                                       test_token.length() + 1,
+                                       test_token.c_str()),
+            QDMI_SUCCESS)
+      << "Failed to set session parameter";
+
   ASSERT_EQ(QDMI_session_get_devices(session, 1, &device, nullptr),
             QDMI_SUCCESS)
       << "Failed to get device";
@@ -258,4 +265,50 @@ TEST_P(QDMIImplementationTest, ControlDeviceModeReadOnly) {
   EXPECT_EQ(QDMI_control_get_data(device, job, QDMI_JOB_RESULT_MAX, 0, nullptr,
                                   nullptr),
             QDMI_ERROR_PERMISSIONDENIED);
+}
+
+TEST_P(QDMIImplementationTest, SessionGetDevicesImplemented) {
+  ASSERT_EQ(QDMI_session_get_devices(session, 0, nullptr, nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+
+  ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_TOKEN, 0,
+                                       nullptr),
+            QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_OWNER, 0,
+                                       nullptr),
+            QDMI_SUCCESS);
+  std::array<QDMI_Device, 2> devices{};
+  ASSERT_EQ(QDMI_session_get_devices(session, 2, devices.data(), nullptr),
+            QDMI_ERROR_PERMISSIONDENIED);
+
+  std::string test_token = "test_token";
+  ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_TOKEN,
+                                       test_token.length() + 1,
+                                       test_token.c_str()),
+            QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_session_get_devices(session, 2, devices.data(), nullptr),
+            QDMI_SUCCESS);
+}
+
+TEST_P(QDMIImplementationTest, SessionSetParameterImplemented) {
+  ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_MAX, 0,
+                                       nullptr),
+            QDMI_ERROR_INVALIDARGUMENT);
+
+  std::string test_token = "test_token";
+  ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_TOKEN,
+                                       test_token.length() + 1,
+                                       test_token.c_str()),
+            QDMI_SUCCESS);
+
+  std::string test_owner = "test_owner";
+  ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_OWNER,
+                                       test_owner.length() + 1,
+                                       test_owner.c_str()),
+            QDMI_SUCCESS);
+
+  ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_CUSTOM_1,
+                                       test_owner.length() + 1,
+                                       test_owner.c_str()),
+            QDMI_ERROR_NOTSUPPORTED);
 }

--- a/test/utils/test_impl.cpp
+++ b/test/utils/test_impl.cpp
@@ -64,7 +64,7 @@ void QDMIImplementationTest::SetUp() {
   ASSERT_EQ(QDMI_session_alloc(&session), QDMI_SUCCESS)
       << "Failed to allocate session";
 
-  std::string test_token = "test_token";
+  const std::string test_token = "test_token";
   ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_TOKEN,
                                        test_token.length() + 1,
                                        test_token.c_str()),
@@ -281,7 +281,7 @@ TEST_P(QDMIImplementationTest, SessionGetDevicesImplemented) {
   ASSERT_EQ(QDMI_session_get_devices(session, 2, devices.data(), nullptr),
             QDMI_ERROR_PERMISSIONDENIED);
 
-  std::string test_token = "test_token";
+  const std::string test_token = "test_token";
   ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_TOKEN,
                                        test_token.length() + 1,
                                        test_token.c_str()),
@@ -295,13 +295,13 @@ TEST_P(QDMIImplementationTest, SessionSetParameterImplemented) {
                                        nullptr),
             QDMI_ERROR_INVALIDARGUMENT);
 
-  std::string test_token = "test_token";
+  const std::string test_token = "test_token";
   ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_TOKEN,
                                        test_token.length() + 1,
                                        test_token.c_str()),
             QDMI_SUCCESS);
 
-  std::string test_owner = "test_owner";
+  const std::string test_owner = "test_owner";
   ASSERT_EQ(QDMI_session_set_parameter(session, QDMI_SESSION_PARAMETER_OWNER,
                                        test_owner.length() + 1,
                                        test_owner.c_str()),


### PR DESCRIPTION
Closes #96 

- Added function `QDMI_session_set_parameter` to set session parameters 
- Added enum `QDMI_SESSION_PARAMETER_T` to be used as parameter to `QDMI_session_set_parameter`
- Added two enum values `QDMI_SESSION_PARAMETER_OWNER` and `QDMI_SESSION_PARAMETER_TOKEN` to `QDMI_SESSION_PARAMETER_T` to be used for access control within a session. 