### PR TITLE
🐛 Fix an inconsistency in the docs about coupling maps

### DIFF
--- a/include/qdmi/common/enums.h
+++ b/include/qdmi/common/enums.h
@@ -42,13 +42,15 @@ enum QDMI_DEVICE_PROPERTY_T {
   /// `size_t` The number of qubits in the device.
   QDMI_DEVICE_PROPERTY_QUBITSNUM,
   /**
-   * @brief `int*` (int list) The coupling map of the device.
-   * @details The returned list contains pairs of qubits that are coupled. The
-   * pairs in the list are flattened such that the first qubit of the pair is at
-   * index 2n and the second qubit is at index 2n+1. For example, a 2-qubit
-   * device with a coupling map of (0, 1) would return `{0, 1}`. A
-   * 3-qubit device with a coupling map of (0, 1), (1, 2) would return
-   * `{0, 1, 1, 2}`.
+   * @brief `QDMI_Site*` (@ref QDMI_Site list) The coupling map of the device.
+   * @details The returned list contains pairs of sites that are coupled. The
+   * pairs in the list are flattened such that the first site of the pair is at
+   * index 2n and the second site is at index 2n+1.
+   *
+   * The sites returned in that list are represented as a pointer to the
+   * respective @ref QDMI_Site. For example, consider a 3-site device with a
+   * coupling map (0, 1), (1, 2). Additionally, `site_i` is the pointer to the
+   * i-th site. Then, `{site_0, site_1, site_1, site_2}` would be returned.
    */
   QDMI_DEVICE_PROPERTY_COUPLINGMAP,
   /**


### PR DESCRIPTION
This PR fixes an inconsistency that was present in the documentation of the coupling map parameter, and that was reported in #119.

Fixes #119