### PR TITLE
🩹 fix potential target conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,14 +102,14 @@ include(GNUInstallDirs)
 # add warnings target
 if(NOT TARGET qdmi::project_warnings)
   # use the warnings specified in CompilerWarnings.cmake
-  add_library(project_warnings INTERFACE)
+  add_library(qdmi_project_warnings INTERFACE)
 
   # standard compiler warnings
   include(${PROJECT_SOURCE_DIR}/cmake/CompilerWarnings.cmake)
-  set_project_warnings(project_warnings)
+  set_project_warnings(qdmi_project_warnings)
 
   # add alias
-  add_library(qdmi::project_warnings ALIAS project_warnings)
+  add_library(qdmi::project_warnings ALIAS qdmi_project_warnings)
 endif()
 
 # add main library code

--- a/examples/driver/CMakeLists.txt
+++ b/examples/driver/CMakeLists.txt
@@ -23,7 +23,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_library(qdmi_example_driver qdmi_example_driver.cpp qdmi_example_driver.h)
-target_link_libraries(qdmi_example_driver PRIVATE qdmi::qdmi)
+target_link_libraries(qdmi_example_driver PRIVATE qdmi::qdmi
+                                                  qdmi::project_warnings)
 target_include_directories(qdmi_example_driver
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(qdmi_example_driver PROPERTIES POSITION_INDEPENDENT_CODE

--- a/examples/fomac/CMakeLists.txt
+++ b/examples/fomac/CMakeLists.txt
@@ -23,7 +23,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_library(qdmi_example_fomac example_fomac.cpp example_fomac.hpp)
-target_link_libraries(qdmi_example_fomac PRIVATE qdmi::qdmi)
+target_link_libraries(qdmi_example_fomac PRIVATE qdmi::qdmi
+                                                 qdmi::project_warnings)
 target_include_directories(qdmi_example_fomac
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(qdmi::example_fomac ALIAS qdmi_example_fomac)


### PR DESCRIPTION
Fixes #116
by adding a `qdmi_` prefix to the `project_warnings` target.