### PR TITLE
✨ Provide an option to specify the supported QIR profile

### DIFF
--- a/examples/device/c/device.c
+++ b/examples/device/c/device.c
@@ -303,18 +303,23 @@ int C_QDMI_query_operation_property_dev(C_QDMI_Operation operation,
 int C_QDMI_control_create_job_dev(const QDMI_Program_Format format,
                                   const size_t size, const void *prog,
                                   C_QDMI_Job *job) {
+  if (format != QDMI_PROGRAM_FORMAT_QASM2 &&
+      format != QDMI_PROGRAM_FORMAT_QIRBASESTRING &&
+      format != QDMI_PROGRAM_FORMAT_QIRBASEMODULE) {
+    if (prog != NULL && (size <= 0 || job == NULL)) {
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
+    return QDMI_ERROR_NOTSUPPORTED;
+  }
+  if (prog == NULL) {
+    return QDMI_SUCCESS;
+  }
+  if (size == 0 || job == NULL) {
+    return QDMI_ERROR_INVALIDARGUMENT;
+  }
   if (C_QDMI_read_device_status() != QDMI_DEVICE_STATUS_IDLE) {
     return QDMI_ERROR_FATAL;
   }
-  if (size == 0 || prog == NULL || job == NULL) {
-    return QDMI_ERROR_INVALIDARGUMENT;
-  }
-  if (format != QDMI_PROGRAM_FORMAT_QASM2 &&
-      format != QDMI_PROGRAM_FORMAT_QIRSTRING &&
-      format != QDMI_PROGRAM_FORMAT_QIRMODULE) {
-    return QDMI_ERROR_NOTSUPPORTED;
-  }
-
   *job = (C_QDMI_Job)malloc(sizeof(C_QDMI_Job_impl_t));
   // set job id to random number for demonstration purposes
   (*job)->id = rand();

--- a/examples/device/c/device.c
+++ b/examples/device/c/device.c
@@ -303,7 +303,7 @@ int C_QDMI_query_operation_property_dev(C_QDMI_Operation operation,
 int C_QDMI_control_create_job_dev(const QDMI_Program_Format format,
                                   const size_t size, const void *prog,
                                   C_QDMI_Job *job) {
-  if (prog != NULL && (size <= 0 || job == NULL)) {
+  if (prog != NULL && (size == 0 || job == NULL)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (format != QDMI_PROGRAM_FORMAT_QASM2 &&

--- a/examples/device/c/device.c
+++ b/examples/device/c/device.c
@@ -303,19 +303,16 @@ int C_QDMI_query_operation_property_dev(C_QDMI_Operation operation,
 int C_QDMI_control_create_job_dev(const QDMI_Program_Format format,
                                   const size_t size, const void *prog,
                                   C_QDMI_Job *job) {
+  if (prog != NULL && (size <= 0 || job == NULL)) {
+    return QDMI_ERROR_INVALIDARGUMENT;
+  }
   if (format != QDMI_PROGRAM_FORMAT_QASM2 &&
       format != QDMI_PROGRAM_FORMAT_QIRBASESTRING &&
       format != QDMI_PROGRAM_FORMAT_QIRBASEMODULE) {
-    if (prog != NULL && (size <= 0 || job == NULL)) {
-      return QDMI_ERROR_INVALIDARGUMENT;
-    }
     return QDMI_ERROR_NOTSUPPORTED;
   }
   if (prog == NULL) {
     return QDMI_SUCCESS;
-  }
-  if (size == 0 || job == NULL) {
-    return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (C_QDMI_read_device_status() != QDMI_DEVICE_STATUS_IDLE) {
     return QDMI_ERROR_FATAL;

--- a/examples/device/cxx/device.cpp
+++ b/examples/device/cxx/device.cpp
@@ -380,19 +380,16 @@ int CXX_QDMI_query_operation_property_dev(
 int CXX_QDMI_control_create_job_dev(const QDMI_Program_Format format,
                                     const size_t size, const void *prog,
                                     CXX_QDMI_Job *job) {
+  if (prog != nullptr && (size == 0 || job == nullptr)) {
+    return QDMI_ERROR_INVALIDARGUMENT;
+  }
   if (format != QDMI_PROGRAM_FORMAT_QASM2 &&
       format != QDMI_PROGRAM_FORMAT_QIRBASESTRING &&
       format != QDMI_PROGRAM_FORMAT_QIRBASEMODULE) {
-    if (prog != nullptr && (size == 0 || job == nullptr)) {
-      return QDMI_ERROR_INVALIDARGUMENT;
-    }
     return QDMI_ERROR_NOTSUPPORTED;
   }
   if (prog == nullptr) {
     return QDMI_SUCCESS;
-  }
-  if (size <= 0 || job == nullptr) {
-    return QDMI_ERROR_INVALIDARGUMENT;
   }
   if (CXX_QDMI_get_device_status() != QDMI_DEVICE_STATUS_IDLE) {
     return QDMI_ERROR_FATAL;

--- a/examples/device/cxx/device.cpp
+++ b/examples/device/cxx/device.cpp
@@ -380,16 +380,22 @@ int CXX_QDMI_query_operation_property_dev(
 int CXX_QDMI_control_create_job_dev(const QDMI_Program_Format format,
                                     const size_t size, const void *prog,
                                     CXX_QDMI_Job *job) {
-  if (CXX_QDMI_get_device_status() != QDMI_DEVICE_STATUS_IDLE) {
-    return QDMI_ERROR_FATAL;
+  if (format != QDMI_PROGRAM_FORMAT_QASM2 &&
+      format != QDMI_PROGRAM_FORMAT_QIRBASESTRING &&
+      format != QDMI_PROGRAM_FORMAT_QIRBASEMODULE) {
+    if (prog != nullptr && (size == 0 || job == nullptr)) {
+      return QDMI_ERROR_INVALIDARGUMENT;
+    }
+    return QDMI_ERROR_NOTSUPPORTED;
   }
-  if (size == 0 || prog == nullptr || job == nullptr) {
+  if (prog == nullptr) {
+    return QDMI_SUCCESS;
+  }
+  if (size <= 0 || job == nullptr) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
-  if (format != QDMI_PROGRAM_FORMAT_QASM2 &&
-      format != QDMI_PROGRAM_FORMAT_QIRSTRING &&
-      format != QDMI_PROGRAM_FORMAT_QIRMODULE) {
-    return QDMI_ERROR_NOTSUPPORTED;
+  if (CXX_QDMI_get_device_status() != QDMI_DEVICE_STATUS_IDLE) {
+    return QDMI_ERROR_FATAL;
   }
 
   *job = new CXX_QDMI_Job_impl_d;

--- a/include/qdmi/client/control.h
+++ b/include/qdmi/client/control.h
@@ -43,18 +43,21 @@ extern "C" {
  * number of shots (@ref QDMI_JOB_PARAMETER_SHOTS_NUM) can be set via @ref
  * QDMI_control_submit_job. After setting all parameters, the job must be
  * submitted for execution through @ref QDMI_control_submit_job.
- * @param[in] dev The device to create the job on.
+ * @param[in] dev identifies the device to create the job on.
  * @param[in] format is the format of the program, see @ref
  * QDMI_PROGRAM_FORMAT_T for available options. Note that the availability also
  * depends on the device.
  * @param[in] size is the number of bytes of the program.
- * @param[in] prog is the program to run.
+ * @param[in] prog is the program to run. If this is @c NULL, it is ignored.
  * @param[out] job is a handle to the job created.
- * @return @ref QDMI_SUCCESS if the job was successfully created.
- * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p size is zero or the program
- * @p prog is invalid, e.g. @c NULL.
+ * @return @ref QDMI_SUCCESS if the device supports the given @ref
+ * QDMI_Program_Format @p format and, if @p prog was not
+ * @c NULL, if the job was successfully created.
+ * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p prog is not @c NULL and @p size
+ * is less than or equal to zero or the program @p prog is invalid, e.g. a
+ * syntax error.
  * @return @ref QDMI_ERROR_NOTSUPPORTED if the device does not support the
- * program format.
+ * program format @p format.
  * @return @ref QDMI_ERROR_FATAL if the job creation failed.
  */
 int QDMI_control_create_job(QDMI_Device dev, QDMI_Program_Format format,

--- a/include/qdmi/client/control.h
+++ b/include/qdmi/client/control.h
@@ -39,26 +39,33 @@ extern "C" {
 
 /**
  * @brief Create a job on a device.
- * @details Create a job consisting of a circuit. Other parameters like the
- * number of shots (@ref QDMI_JOB_PARAMETER_SHOTS_NUM) can be set via @ref
- * QDMI_control_submit_job. After setting all parameters, the job must be
- * submitted for execution through @ref QDMI_control_submit_job.
+ * @details This function creates a job that consists of a circuit.
+ * Additional parameters, such as the number of shots, can be set using @ref
+ * QDMI_control_set_parameter_dev. After setting all necessary parameters, the
+ * job must be submitted for execution using @ref QDMI_control_submit_job.
  * @param[in] dev identifies the device to create the job on.
- * @param[in] format is the format of the program, see @ref
- * QDMI_PROGRAM_FORMAT_T for available options. Note that the availability also
- * depends on the device.
- * @param[in] size is the number of bytes of the program.
+ * @param[in] format is the format of the program. Refer to @ref
+ * QDMI_PROGRAM_FORMAT_T for available options. Note that the availability of
+ * formats depends on the device.
+ * @param[in] size is the size of the program in bytes.
  * @param[in] prog is the program to run. If this is @c NULL, it is ignored.
- * @param[out] job is a handle to the job created.
- * @return @ref QDMI_SUCCESS if the device supports the given @ref
- * QDMI_Program_Format @p format and, if @p prog was not
- * @c NULL, if the job was successfully created.
+ * @param[out] job is a pointer to a handle that will store the created job.
+ * Must not be @c NULL, except when @p prog is @c NULL, in which case it is
+ * ignored.
+ * @return @ref QDMI_SUCCESS if the device supports the specified @ref
+ * QDMI_Program_Format @p format and, when @p prog is not @c NULL, the job was
+ * successfully created.
  * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p prog is not @c NULL and @p size
- * is less than or equal to zero or the program @p prog is invalid, e.g. a
- * syntax error.
+ * is less than or equal to zero, or the program @p prog is invalid (e.g.,
+ * contains a syntax error).
  * @return @ref QDMI_ERROR_NOTSUPPORTED if the device does not support the
- * program format @p format.
- * @return @ref QDMI_ERROR_FATAL if the job creation failed.
+ * specified program format @p format.
+ * @return @ref QDMI_ERROR_FATAL if the job creation failed due to a fatal
+ * error.
+ *
+ * @note By calling this function with @p prog and @p job set to @c NULL, the
+ * function can be used to check if the device supports the specified program
+ * format without creating a job and without the need to provide a program.
  */
 int QDMI_control_create_job(QDMI_Device dev, QDMI_Program_Format format,
                             size_t size, const void *prog, QDMI_Job *job);

--- a/include/qdmi/client/control.h
+++ b/include/qdmi/client/control.h
@@ -41,7 +41,7 @@ extern "C" {
  * @brief Create a job on a device.
  * @details This function creates a job that consists of a circuit.
  * Additional parameters, such as the number of shots, can be set using @ref
- * QDMI_control_set_parameter_dev. After setting all necessary parameters, the
+ * QDMI_control_set_parameter. After setting all necessary parameters, the
  * job must be submitted for execution using @ref QDMI_control_submit_job.
  * @param[in] dev identifies the device to create the job on.
  * @param[in] format is the format of the program. Refer to @ref
@@ -56,7 +56,7 @@ extern "C" {
  * QDMI_Program_Format @p format and, when @p prog is not @c NULL, the job was
  * successfully created.
  * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p prog is not @c NULL and @p size
- * is less than or equal to zero, or the program @p prog is invalid (e.g.,
+ * is equal to zero, or the program @p prog is invalid (e.g.,
  * contains a syntax error).
  * @return @ref QDMI_ERROR_NOTSUPPORTED if the device does not support the
  * specified program format @p format.

--- a/include/qdmi/common/enums.h
+++ b/include/qdmi/common/enums.h
@@ -211,19 +211,19 @@ enum QDMI_STATUS {
  * @brief Enum of formats that can be submitted to the device.
  */
 enum QDMI_PROGRAM_FORMAT_T {
-  /// `char*`(string) The OpenQASM 2.0 program to run.
+  /// `char*`(string) An OpenQASM 2.0 program.
   QDMI_PROGRAM_FORMAT_QASM2 = 0,
-  /// `char*`(string) The OpenQASM 3 program to run.
+  /// `char*`(string) An OpenQASM 3.0 program.
   QDMI_PROGRAM_FORMAT_QASM3 = 1,
-  /// `char*`(string) The QIR program satisfying the base profile as a string.
+  /// `char*`(string) A text-based QIR program complying to the QIR base
+  /// profile.
   QDMI_PROGRAM_FORMAT_QIRBASESTRING = 2,
-  /// `void*` The QIR program satisfying the base profile as a binary module.
+  /// `void*` A QIR binary complying to the QIR base profile.
   QDMI_PROGRAM_FORMAT_QIRBASEMODULE = 3,
-  /// `char*`(string) The QIR program satisfying the adaptive profile as a
-  /// string.
+  /// `char*`(string) A text-based QIR program complying to the QIR adaptive
+  /// profile.
   QDMI_PROGRAM_FORMAT_QIRADAPTIVESTRING = 4,
-  /// `void*` The QIR program satisfying the adaptive profile as a binary
-  /// module.
+  /// `void*` A QIR binary complying to the QIR adaptive profile.
   QDMI_PROGRAM_FORMAT_QIRADAPTIVEMODULE = 5,
   /**
    * @brief The maximum value of the enum.

--- a/include/qdmi/common/enums.h
+++ b/include/qdmi/common/enums.h
@@ -215,10 +215,16 @@ enum QDMI_PROGRAM_FORMAT_T {
   QDMI_PROGRAM_FORMAT_QASM2 = 0,
   /// `char*`(string) The OpenQASM 3 program to run.
   QDMI_PROGRAM_FORMAT_QASM3 = 1,
-  /// `char*`(string) The QIR program to run as a string.
-  QDMI_PROGRAM_FORMAT_QIRSTRING = 2,
-  /// `void*` The QIR program as a binary module.
-  QDMI_PROGRAM_FORMAT_QIRMODULE = 3,
+  /// `char*`(string) The QIR program satisfying the base profile as a string.
+  QDMI_PROGRAM_FORMAT_QIRBASESTRING = 2,
+  /// `void*` The QIR program satisfying the base profile as a binary module.
+  QDMI_PROGRAM_FORMAT_QIRBASEMODULE = 3,
+  /// `char*`(string) The QIR program satisfying the adaptive profile as a
+  /// string.
+  QDMI_PROGRAM_FORMAT_QIRADAPTIVESTRING = 4,
+  /// `void*` The QIR program satisfying the adaptive profile as a binary
+  /// module.
+  QDMI_PROGRAM_FORMAT_QIRADAPTIVEMODULE = 5,
   /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
@@ -226,7 +232,7 @@ enum QDMI_PROGRAM_FORMAT_T {
    * enum besides the custom members and must be updated when new members are
    * added.
    */
-  QDMI_PROGRAM_FORMAT_MAX = 4,
+  QDMI_PROGRAM_FORMAT_MAX = 6,
   /**
    * @brief This property is reserved for a custom property.
    * @details The meaning and the type of this property are defined by the

--- a/include/qdmi/device/control.h
+++ b/include/qdmi/device/control.h
@@ -37,25 +37,32 @@ extern "C" {
 
 /**
  * @brief Create a job on a device.
- * @details Create a job consisting of a circuit. Other parameters like the
- * number of shots (@ref QDMI_JOB_PARAMETER_SHOTS_NUM) can be set via @ref
- * QDMI_control_submit_job. After setting all parameters, the job must be
- * submitted for execution through @ref QDMI_control_submit_job.
- * @param[in] format is the format of the program, see @ref
- * QDMI_PROGRAM_FORMAT_T for available options. Note that the availability also
- * depends on the device.
- * @param[in] size is the number of bytes of the program.
+ * @details This function creates a job that consists of a circuit.
+ * Additional parameters, such as the number of shots, can be set using @ref
+ * QDMI_control_set_parameter_dev. After setting all necessary parameters, the
+ * job must be submitted for execution using @ref QDMI_control_submit_job_dev.
+ * @param[in] format is the format of the program. Refer to @ref
+ * QDMI_PROGRAM_FORMAT_T for available options. Note that the availability of
+ * formats depends on the device.
+ * @param[in] size is the size of the program in bytes.
  * @param[in] prog is the program to run. If this is @c NULL, it is ignored.
- * @param[out] job is a handle to the job created.
- * @return @ref QDMI_SUCCESS if the device supports the given @ref
- * QDMI_Program_Format @p format and, if @p prog was not
- * @c NULL, if the job was successfully created.
+ * @param[out] job is a pointer to a handle that will store the created job.
+ * Must not be @c NULL, except when @p prog is @c NULL, in which case it is
+ * ignored.
+ * @return @ref QDMI_SUCCESS if the device supports the specified @ref
+ * QDMI_Program_Format @p format and, when @p prog is not @c NULL, the job was
+ * successfully created.
  * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p prog is not @c NULL and @p size
- * is less than or equal to zero or the program @p prog is invalid, e.g. a
- * syntax error.
+ * is less than or equal to zero, or the program @p prog is invalid (e.g.,
+ * contains a syntax error).
  * @return @ref QDMI_ERROR_NOTSUPPORTED if the device does not support the
- * program format @p format.
- * @return @ref QDMI_ERROR_FATAL if the job creation failed.
+ * specified program format @p format.
+ * @return @ref QDMI_ERROR_FATAL if the job creation failed due to a fatal
+ * error.
+ *
+ * @note By calling this function with @p prog and @p job set to @c NULL, the
+ * function can be used to check if the device supports the specified program
+ * format without creating a job and without the need to provide a program.
  */
 int QDMI_control_create_job_dev(QDMI_Program_Format format, size_t size,
                                 const void *prog, QDMI_Job *job);

--- a/include/qdmi/device/control.h
+++ b/include/qdmi/device/control.h
@@ -45,13 +45,16 @@ extern "C" {
  * QDMI_PROGRAM_FORMAT_T for available options. Note that the availability also
  * depends on the device.
  * @param[in] size is the number of bytes of the program.
- * @param[in] prog is the program to run.
+ * @param[in] prog is the program to run. If this is @c NULL, it is ignored.
  * @param[out] job is a handle to the job created.
- * @return @ref QDMI_SUCCESS if the job was successfully created.
- * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p size is less than or equal to
- * zero or the program @p prog is invalid, e.g. @c NULL.
+ * @return @ref QDMI_SUCCESS if the device supports the given @ref
+ * QDMI_Program_Format @p format and, if @p prog was not
+ * @c NULL, if the job was successfully created.
+ * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p prog is not @c NULL and @p size
+ * is less than or equal to zero or the program @p prog is invalid, e.g. a
+ * syntax error.
  * @return @ref QDMI_ERROR_NOTSUPPORTED if the device does not support the
- * program format.
+ * program format @p format.
  * @return @ref QDMI_ERROR_FATAL if the job creation failed.
  */
 int QDMI_control_create_job_dev(QDMI_Program_Format format, size_t size,

--- a/include/qdmi/device/control.h
+++ b/include/qdmi/device/control.h
@@ -53,7 +53,7 @@ extern "C" {
  * QDMI_Program_Format @p format and, when @p prog is not @c NULL, the job was
  * successfully created.
  * @return @ref QDMI_ERROR_INVALIDARGUMENT if @p prog is not @c NULL and @p size
- * is less than or equal to zero, or the program @p prog is invalid (e.g.,
+ * is equal to zero, or the program @p prog is invalid (e.g.,
  * contains a syntax error).
  * @return @ref QDMI_ERROR_NOTSUPPORTED if the device does not support the
  * specified program format @p format.

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -189,6 +189,10 @@ TEST_P(QDMIImplementationTest, ControlJob) {
                                        sizeof(size_t), &shots),
             QDMI_SUCCESS);
   ASSERT_EQ(QDMI_control_submit_job(device, job), QDMI_SUCCESS);
+  QDMI_Job job2 = nullptr;
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    input.length() + 1, input.c_str(), &job2),
+            QDMI_ERROR_FATAL);
   EXPECT_EQ(QDMI_control_submit_job(device, job), QDMI_ERROR_INVALIDARGUMENT);
   QDMI_Job_Status status{};
   EXPECT_EQ(QDMI_control_check(device, job, &status), QDMI_SUCCESS);

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -143,9 +143,16 @@ TEST_P(QDMIImplementationTest, ControlJob) {
                             "qreg q[2];\n"
                             "h q[0];\n"
                             "cx q[0], q[1];\n";
-  EXPECT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2, 1,
-                                    nullptr, &job),
+  EXPECT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
+                                    input.length() + 1, input.c_str(), nullptr),
             QDMI_ERROR_INVALIDARGUMENT);
+  EXPECT_EQ(QDMI_control_create_job(device,
+                                    QDMI_PROGRAM_FORMAT_QIRADAPTIVEMODULE, 0,
+                                    nullptr, nullptr),
+            QDMI_ERROR_NOTSUPPORTED);
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2, 0,
+                                    nullptr, nullptr),
+            QDMI_SUCCESS);
   ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
                                     input.length() + 1, input.c_str(), &job),
             QDMI_SUCCESS);

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -146,6 +146,15 @@ TEST_P(QDMIImplementationTest, ControlJob) {
   EXPECT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
                                     input.length() + 1, input.c_str(), nullptr),
             QDMI_ERROR_INVALIDARGUMENT);
+
+  // Test format support
+  EXPECT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM3, 0,
+                                    nullptr, nullptr),
+            QDMI_ERROR_NOTSUPPORTED);
+  EXPECT_EQ(QDMI_control_create_job(device,
+                                    QDMI_PROGRAM_FORMAT_QIRADAPTIVESTRING, 0,
+                                    nullptr, nullptr),
+            QDMI_ERROR_NOTSUPPORTED);
   EXPECT_EQ(QDMI_control_create_job(device,
                                     QDMI_PROGRAM_FORMAT_QIRADAPTIVEMODULE, 0,
                                     nullptr, nullptr),
@@ -153,6 +162,14 @@ TEST_P(QDMIImplementationTest, ControlJob) {
   ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2, 0,
                                     nullptr, nullptr),
             QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QIRBASEMODULE,
+                                    0, nullptr, nullptr),
+            QDMI_SUCCESS);
+  ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QIRBASESTRING,
+                                    0, nullptr, nullptr),
+            QDMI_SUCCESS);
+
+  // Test actual job creation and submission
   ASSERT_EQ(QDMI_control_create_job(device, QDMI_PROGRAM_FORMAT_QASM2,
                                     input.length() + 1, input.c_str(), &job),
             QDMI_SUCCESS);


### PR DESCRIPTION
This PR provides the solution as discussed in issue #115. Hence, it is possible to first ask a device whether a certain job format is supported before actually submitting the program in that format.

Fixes #115 