### PR TITLE
✨ Add `ID` as a Site Property

### DIFF
--- a/examples/device/c/device.c
+++ b/examples/device/c/device.c
@@ -218,6 +218,8 @@ int C_QDMI_query_site_property_dev(C_QDMI_Site site,
       (value == NULL && size_ret == NULL)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_ID, size_t, site->id, prop, size,
+                            value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_TIME_T1, double, 1000.0, prop,
                             size, value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_TIME_T2, double, 100000.0, prop,

--- a/examples/device/cxx/device.cpp
+++ b/examples/device/cxx/device.cpp
@@ -317,6 +317,8 @@ int CXX_QDMI_query_site_property_dev(CXX_QDMI_Site site,
       (value == nullptr && size_ret == nullptr)) {
     return QDMI_ERROR_INVALIDARGUMENT;
   }
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_ID, size_t, site->id, prop, size,
+                            value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_TIME_T1, double, 1000.0, prop,
                             size, value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_TIME_T2, double, 100000.0, prop,

--- a/examples/device/cxx/device.cpp
+++ b/examples/device/cxx/device.cpp
@@ -136,7 +136,7 @@ std::array<CXX_QDMI_Operation_impl_d, 4> device_operations = {
     CXX_QDMI_Operation_impl_d{"rx"}, CXX_QDMI_Operation_impl_d{"ry"},
     CXX_QDMI_Operation_impl_d{"rz"}, CXX_QDMI_Operation_impl_d{"cx"}};
 
-std::array<CXX_QDMI_Site_impl_d, 7> device_sites = {
+std::array<CXX_QDMI_Site_impl_d, 5> device_sites = {
     CXX_QDMI_Site_impl_d{0}, CXX_QDMI_Site_impl_d{1}, CXX_QDMI_Site_impl_d{2},
     CXX_QDMI_Site_impl_d{3}, CXX_QDMI_Site_impl_d{4}};
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)

--- a/examples/fomac/example_fomac.cpp
+++ b/examples/fomac/example_fomac.cpp
@@ -110,6 +110,14 @@ auto FoMaC::get_qubits_num() const -> size_t {
   return num_qubits;
 }
 
+auto FoMaC::get_site_id(QDMI_Site site) const -> size_t {
+  size_t site_id = 0;
+  const int ret = QDMI_query_site_property(device, site, QDMI_SITE_PROPERTY_ID,
+                                           sizeof(size_t), &site_id, nullptr);
+  throw_if_error(ret, "Failed to query the number of qubits.");
+  return site_id;
+}
+
 auto FoMaC::get_operation_map() const -> std::map<std::string, QDMI_Operation> {
   size_t ops_num = 0;
   int ret = QDMI_query_get_operations(device, 0, nullptr, &ops_num);

--- a/examples/fomac/example_fomac.hpp
+++ b/examples/fomac/example_fomac.hpp
@@ -44,6 +44,8 @@ public:
 
   [[nodiscard]] auto get_qubits_num() const -> size_t;
 
+  [[nodiscard]] auto get_site_id(QDMI_Site site) const -> size_t;
+
   [[nodiscard]] auto get_operation_map() const
       -> std::map<std::string, QDMI_Operation>;
 

--- a/include/qdmi/common/enums.h
+++ b/include/qdmi/common/enums.h
@@ -98,8 +98,20 @@ enum QDMI_DEVICE_STATUS_T {
 
 /// Enum of the site properties that can be queried.
 enum QDMI_SITE_PROPERTY_T {
-  /// `size_t` The id to identify the site in the circuit.
-  /// @details For example, `q[1]` in a QASM code identifies the site with id 1.
+  /**
+   * @brief `size_t` The id to identify the site in the circuit.
+   * @details For example, `$0` in a QASM code identifies the (physical) site
+   * with id 1. Note, those physical qubits in the QASM language should not be
+   * confused with the virtual qubits used more frequently. Those are allocated
+   * via `qreg q[3]`, for example, and then used in the circuit as, e.g.,
+   * `h q[0]`.
+   *
+   * @par
+   * On the QIR side, there is also the distinction between dynamically
+   * allocated and static hardware qubits. Here, only the latter refer to the
+   * physical ids of sites. E.g., `ptr inttoptr (i64 1 to ptr)` refers to the
+   * physical site with id 1.
+   */
   QDMI_SITE_PROPERTY_ID = 0,
   QDMI_SITE_PROPERTY_TIME_T1 = 1, ///< `double` The T1 time of a site in µs.
   QDMI_SITE_PROPERTY_TIME_T2 = 2, ///< `double` The T2 time of a site in µs.

--- a/include/qdmi/common/enums.h
+++ b/include/qdmi/common/enums.h
@@ -98,8 +98,11 @@ enum QDMI_DEVICE_STATUS_T {
 
 /// Enum of the site properties that can be queried.
 enum QDMI_SITE_PROPERTY_T {
-  QDMI_SITE_PROPERTY_TIME_T1 = 0, ///< `double` The T1 time of a site in µs.
-  QDMI_SITE_PROPERTY_TIME_T2 = 1, ///< `double` The T2 time of a site in µs.
+  /// `size_t` The id to identify the site in the circuit.
+  /// @details For example, `q[1]` in a QASM code identifies the site with id 1.
+  QDMI_SITE_PROPERTY_ID = 0,
+  QDMI_SITE_PROPERTY_TIME_T1 = 1, ///< `double` The T1 time of a site in µs.
+  QDMI_SITE_PROPERTY_TIME_T2 = 2, ///< `double` The T2 time of a site in µs.
   /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
@@ -107,7 +110,7 @@ enum QDMI_SITE_PROPERTY_T {
    * enum besides the custom members and must be updated when new members are
    * added.
    */
-  QDMI_SITE_PROPERTY_MAX = 2,
+  QDMI_SITE_PROPERTY_MAX = 3,
   /**
    * @brief This property is reserved for a custom property.
    * @details The meaning and the type of this property are defined by the

--- a/include/qdmi/common/enums.h
+++ b/include/qdmi/common/enums.h
@@ -101,10 +101,19 @@ enum QDMI_SITE_PROPERTY_T {
   /**
    * @brief `size_t` The id to identify the site in the circuit.
    * @details For example, `$0` in a QASM code identifies the (physical) site
-   * with id 1. Note, those physical qubits in the QASM language should not be
+   * with id 0. Note, those physical qubits in the QASM language should not be
    * confused with the virtual qubits used more frequently. Those are allocated
    * via `qreg q[3]`, for example, and then used in the circuit as, e.g.,
    * `h q[0]`.
+   *
+   * @par
+   * Additionally, the qubits in a QASM program that contain exactly one
+   * register with exactly the same number of qubits as the device has sites is
+   * also handled as physical qubits. For example for a device with three qubits
+   * and a QASM program `qreg q[3]; h q[0]; cx q[0], q[1];`, the operations are
+   * indeed performed on the physical sites with ids 0 and 1. Note here, that
+   * this is not the intended use of virtual qubits in QASM, but because of
+   * their wide adoption in the community, this behavior is also supported.
    *
    * @par
    * On the QIR side, there is also the distinction between dynamically

--- a/templates/device/test/test_my_device.cpp
+++ b/templates/device/test/test_my_device.cpp
@@ -21,6 +21,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <cstddef>
 #include <gtest/gtest.h>
 #include <string>
+#include <vector>
 
 class QDMIImplementationTest : public ::testing::Test {
 protected:
@@ -188,6 +189,23 @@ TEST_F(QDMIImplementationTest, QueryDeviceLibraryVersionImplemented) {
       QDMI_SUCCESS)
       << "Devices must provide a library version";
   ASSERT_FALSE(value.empty()) << "Devices must provide a library version";
+}
+
+TEST_F(QDMIImplementationTest, QuerySiteIDImplemented) {
+  size_t size = 0;
+  ASSERT_EQ(MY_QDMI_query_get_sites_dev(0, nullptr, &size), QDMI_SUCCESS)
+      << "Devices must provide a list of sites";
+  std::vector<MY_QDMI_Site> sites(size);
+  ASSERT_EQ(MY_QDMI_query_get_sites_dev(size, sites.data(), nullptr),
+            QDMI_SUCCESS)
+      << "Devices must provide a list of sites";
+  size_t id = 0;
+  for (const auto site : sites) {
+    ASSERT_EQ(MY_QDMI_query_site_property_dev(site, QDMI_SITE_PROPERTY_ID,
+                                              sizeof(size_t), &id, nullptr),
+              QDMI_SUCCESS)
+        << "Devices must provide a site id";
+  }
 }
 
 TEST_F(QDMIImplementationTest, QubitNum) {

--- a/templates/device/test/test_my_device.cpp
+++ b/templates/device/test/test_my_device.cpp
@@ -200,7 +200,7 @@ TEST_F(QDMIImplementationTest, QuerySiteIDImplemented) {
             QDMI_SUCCESS)
       << "Devices must provide a list of sites";
   size_t id = 0;
-  for (const auto site : sites) {
+  for (auto *site : sites) {
     ASSERT_EQ(MY_QDMI_query_site_property_dev(site, QDMI_SITE_PROPERTY_ID,
                                               sizeof(size_t), &id, nullptr),
               QDMI_SUCCESS)

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -137,12 +137,13 @@ TEST_P(QDMIImplementationTest, QueryGatePropertiesForEachGate) {
 }
 
 TEST_P(QDMIImplementationTest, QuerySiteProperties) {
-  // for every gate in the gate set, query the duration of the gate
+  // get all sites and check whether their count is equal to the number of
+  // qubits
   const auto fomac = FoMaC(device);
   const auto sites = fomac.get_sites();
   const auto qubits_num = fomac.get_qubits_num();
   EXPECT_EQ(sites.size(), qubits_num);
-
+  // for every site check that the site id is less than the number of qubits
   for (const auto &site : sites) {
     const auto site_id = fomac.get_site_id(site);
     EXPECT_LT(site_id, qubits_num);

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -136,6 +136,19 @@ TEST_P(QDMIImplementationTest, QueryGatePropertiesForEachGate) {
   }
 }
 
+TEST_P(QDMIImplementationTest, QuerySiteProperties) {
+  // for every gate in the gate set, query the duration of the gate
+  const auto fomac = FoMaC(device);
+  const auto sites = fomac.get_sites();
+  const auto qubits_num = fomac.get_qubits_num();
+  EXPECT_EQ(sites.size(), qubits_num);
+
+  for (const auto &site : sites) {
+    const auto site_id = fomac.get_site_id(site);
+    EXPECT_LT(site_id, qubits_num);
+  }
+}
+
 TEST_P(QDMIImplementationTest, ControlJob) {
   QDMI_Job job{};
   const std::string input = "OPENQASM 2.0;\n"

--- a/test/utils/test_impl.cpp
+++ b/test/utils/test_impl.cpp
@@ -29,6 +29,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <fstream>
 #include <gtest/gtest.h>
 #include <string>
+#include <vector>
 
 void QDMIImplementationTest::SetUp() {
   auto params = GetParam();
@@ -232,6 +233,23 @@ TEST_P(QDMIImplementationTest, QueryDeviceLibraryVersionImplemented) {
             QDMI_SUCCESS)
       << "Devices must provide a library version";
   ASSERT_FALSE(value.empty()) << "Devices must provide a library version";
+}
+
+TEST_P(QDMIImplementationTest, QuerySiteIDImplemented) {
+  size_t size = 0;
+  ASSERT_EQ(QDMI_query_get_sites(device, 0, nullptr, &size), QDMI_SUCCESS)
+      << "Devices must provide a list of sites";
+  std::vector<QDMI_Site> sites(size);
+  ASSERT_EQ(QDMI_query_get_sites(device, size, sites.data(), nullptr),
+            QDMI_SUCCESS)
+      << "Devices must provide a list of sites";
+  size_t id = 0;
+  for (const auto site : sites) {
+    ASSERT_EQ(QDMI_query_site_property(device, site, QDMI_SITE_PROPERTY_ID,
+                                       sizeof(size_t), &id, nullptr),
+              QDMI_SUCCESS)
+        << "Devices must provide a site id";
+  }
 }
 
 TEST_P(QDMIImplementationTest, ControlDeviceModeReadOnly) {

--- a/test/utils/test_impl.cpp
+++ b/test/utils/test_impl.cpp
@@ -244,7 +244,7 @@ TEST_P(QDMIImplementationTest, QuerySiteIDImplemented) {
             QDMI_SUCCESS)
       << "Devices must provide a list of sites";
   size_t id = 0;
-  for (const auto site : sites) {
+  for (auto *site : sites) {
     ASSERT_EQ(QDMI_query_site_property(device, site, QDMI_SITE_PROPERTY_ID,
                                        sizeof(size_t), &id, nullptr),
               QDMI_SUCCESS)


### PR DESCRIPTION
As pointed out in #128, the software stack wants to address specific sites on the device in the compiled QASM/QIR/... programs. Hence, there must be a way for the client to know the id of a site. For that, this PR add the new `QDMI_SITE_PROPERTY_ID`.

Fixes #128