### PR TITLE
⬆️ Update googletest version and CMake setting

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -75,7 +75,7 @@ if(BUILD_QDMI_TESTS)
       ON
       CACHE BOOL "" FORCE)
   set(GTEST_VERSION
-      1.14.0
+      1.16.0
       CACHE STRING "Google Test version")
   set(GTEST_URL
       https://github.com/google/googletest/archive/refs/tags/v${GTEST_VERSION}.tar.gz

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -8,4 +8,4 @@ target_include_directories(qdmi_test_impl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(qdmi::test_impl ALIAS qdmi_test_impl)
 
 # build gtest as position independent code to link it with the shared library
-set_property(TARGET gtest PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_target_properties(gtest PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
This pull request includes:
- Updating to the latest version of GoogleTest to ensure compatibility and benefit from recent updates and features.
- Refactoring the CMake build configuration to use target-based primitives for improved maintainability and modern practices.