### PR TITLE
🔥🩹 Remove FetchContent fallback for Doxygen

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -15,7 +15,7 @@ jobs:
         if: github.event.action != 'closed'
         uses: ssciwr/doxygen-install@v1
         with:
-          version: "1.12.0"
+          version: "1.13.2"
       - name: Install and Build 🔧
         if: github.event.action != 'closed'
         run: |

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install and Build 🔧
         if: github.event.action != 'closed'
         run: |
-          cmake -S . -B build
+          cmake -S . -B build -DBUILD_QDMI_DOCS=ON
           cmake --build build --target qdmi_docs
           mv build/docs/html/ static
       - name: Deploy preview 🚀 (for PRs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,8 @@ option(BUILD_QDMI_TESTS "Also build tests for the QDMI project"
        ${QDMI_MASTER_PROJECT})
 option(BUILD_QDMI_EXAMPLES "Also build examples for the QDMI project"
        ${QDMI_MASTER_PROJECT})
-option(BUILD_QDMI_DOCS "Also build documentation for the QDMI project"
-       ${QDMI_MASTER_PROJECT})
+# Temporarily making this opt-in until getting Doxygen via FetchContent works
+option(BUILD_QDMI_DOCS "Also build documentation for the QDMI project" OFF)
 option(BUILD_QDMI_TEMPLATES "Also build templates for the QDMI project"
        ${QDMI_MASTER_PROJECT})
 

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -21,29 +21,35 @@ include(CMakeDependentOption)
 set(FETCH_PACKAGES "")
 
 if(BUILD_QDMI_DOCS)
-  set(DOXYGEN_VERSION
-      1.12.0
-      CACHE STRING "Doxygen version")
-  set(DOXYGEN_REV
-      "64dfee0a4b65a4dc3687dfc6b31535a844681ffa"
-      CACHE STRING "Doxygen identifier (tag, branch or commit hash)")
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
-    FetchContent_Declare(
-      Doxygen
-      GIT_REPOSITORY https://github.com/doxygen/doxygen.git
-      GIT_TAG ${DOXYGEN_REV}
-      FIND_PACKAGE_ARGS ${DOXYGEN_VERSION})
-    list(APPEND FETCH_PACKAGES Doxygen)
-  else()
-    find_package(Doxygen ${DOXYGEN_VERSION} QUIET)
-    if(NOT Doxygen_FOUND)
-      FetchContent_Declare(
-        Doxygen
-        GIT_REPOSITORY https://github.com/doxygen/doxygen.git
-        GIT_TAG ${DOXYGEN_REV})
-      list(APPEND FETCH_PACKAGES Doxygen)
-    endif()
-  endif()
+  # Not using FetchContent here, as the source build of doxygen is currently
+  # broken. See https://github.com/doxygen/doxygen/issues/11416 for further
+  # details.
+  find_package(Doxygen 1.12.0 REQUIRED)
+  # cmake-format: off
+  #  set(DOXYGEN_VERSION
+  #      1.12.0
+  #      CACHE STRING "Doxygen version")
+  #  set(DOXYGEN_REV
+  #      "64dfee0a4b65a4dc3687dfc6b31535a844681ffa"
+  #      CACHE STRING "Doxygen identifier (tag, branch or commit hash)")
+  #  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+  #    FetchContent_Declare(
+  #      Doxygen
+  #      GIT_REPOSITORY https://github.com/doxygen/doxygen.git
+  #      GIT_TAG ${DOXYGEN_REV}
+  #      FIND_PACKAGE_ARGS ${DOXYGEN_VERSION})
+  #    list(APPEND FETCH_PACKAGES Doxygen)
+  #  else()
+  #    find_package(Doxygen ${DOXYGEN_VERSION} QUIET)
+  #    if(NOT Doxygen_FOUND)
+  #      FetchContent_Declare(
+  #        Doxygen
+  #        GIT_REPOSITORY https://github.com/doxygen/doxygen.git
+  #        GIT_TAG ${DOXYGEN_REV})
+  #      list(APPEND FETCH_PACKAGES Doxygen)
+  #    endif()
+  #  endif()
+  # cmake-format: on
 
   set(DOXYGEN_AWESOME_VERSION
       1.12.0


### PR DESCRIPTION
As it turned out in #143, the fallback of getting Doxygen via FetchContent and building it from source when it is not installed in a sufficient version is not working in practice due to internal configuration and build errors in Doxygen (see https://github.com/doxygen/doxygen/issues/11416 for further details).
Thus, the documentation builds has been turned into an opt-in feature (now need to pass `-DBUILD_QDMI_DOCS=ON` explicitly) and, whenever enabled, now requires `Doxygen` via `find_package`.

In the process, this PR also updates the doxygen version used in CI to the latest release.

Fixes #143 