### PR TITLE
[WIP] Add workaround for manual doxygen build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,14 +90,15 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS
     ON
     CACHE BOOL "Export compile commands" FORCE)
 
-# Require C standard
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_C_STANDARD_REQUIRED True)
-set(CMAKE_C_EXTENSIONS False)
-
 include(cmake/ExternalDependencies.cmake)
 include(cmake/PrefixHandling.cmake)
 include(GNUInstallDirs)
+# Require C standard only after doxygen has been fetched. Doxygen requires -std
+# be set to cpp17
+target_compile_features(doxygen PUBLIC cxx_std_17)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED True)
+set(CMAKE_C_EXTENSIONS False)
 
 # add warnings target
 if(NOT TARGET qdmi::project_warnings)
@@ -147,6 +148,10 @@ endif()
 
 # add documentation
 if(BUILD_QDMI_DOCS)
+  # target_compile_features(doxygen PUBLIC cxx_std_17)
+  # target_compile_features(doxymain PUBLIC cxx_std_17)
+  # target_compile_features(doxycfg PUBLIC cxx_std_17) set_property(TARGET
+  # doxygen PROPERTY C_STANDARD 17)
   add_subdirectory(docs)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ include(cmake/PrefixHandling.cmake)
 include(GNUInstallDirs)
 # Require C standard only after doxygen has been fetched. Doxygen requires -std
 # be set to cpp17
-target_compile_features(doxygen PUBLIC cxx_std_17)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED True)
 set(CMAKE_C_EXTENSIONS False)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -92,22 +92,36 @@ configure_file(${DOXYGEN_CONFIG_FILE_IN} ${DOXYGEN_CONFIG_FILE_OUT} @ONLY)
 if(${DOXYGEN_EXECUTABLE} STREQUAL "DOXYGEN_EXECUTABLE-NOTFOUND")
   set(DOXYGEN_EXECUTABLE ${doxygen_BINARY_DIR}/bin/doxygen)
   message(STATUS "Setting doxygen binary manually to ${DOXYGEN_EXECUTABLE}")
-endif()
 
-add_custom_command(
-  OUTPUT ${DOXYGEN_OUTPUT_DIR}/html/index.html
-  DEPENDS ${DOXYGEN_INPUT_FILES}
-          ${DOXYGEN_CONFIG_FILE_IN}
-          ${CMAKE_CURRENT_SOURCE_DIR}/header.html
-          ${CMAKE_CURRENT_SOURCE_DIR}/layout.xml
-          ${CMAKE_CURRENT_SOURCE_DIR}/style.css
-          ${CMAKE_SOURCE_DIR}/README.md
-          ${CMAKE_SOURCE_DIR}/.github/support.md
-          doxygen # Run only after the doxygen target has been done
-  COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG_FILE_OUT}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMENT "Generating API documentation with Doxygen"
-  VERBATIM)
+  add_custom_command(
+    OUTPUT ${DOXYGEN_OUTPUT_DIR}/html/index.html
+    DEPENDS ${DOXYGEN_INPUT_FILES}
+            ${DOXYGEN_CONFIG_FILE_IN}
+            ${CMAKE_CURRENT_SOURCE_DIR}/header.html
+            ${CMAKE_CURRENT_SOURCE_DIR}/layout.xml
+            ${CMAKE_CURRENT_SOURCE_DIR}/style.css
+            ${CMAKE_SOURCE_DIR}/README.md
+            ${CMAKE_SOURCE_DIR}/.github/support.md
+            doxygen
+    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG_FILE_OUT}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Generating API documentation with Doxygen"
+    VERBATIM)
+else()
+  add_custom_command(
+    OUTPUT ${DOXYGEN_OUTPUT_DIR}/html/index.html
+    DEPENDS ${DOXYGEN_INPUT_FILES}
+            ${DOXYGEN_CONFIG_FILE_IN}
+            ${CMAKE_CURRENT_SOURCE_DIR}/header.html
+            ${CMAKE_CURRENT_SOURCE_DIR}/layout.xml
+            ${CMAKE_CURRENT_SOURCE_DIR}/style.css
+            ${CMAKE_SOURCE_DIR}/README.md
+            ${CMAKE_SOURCE_DIR}/.github/support.md
+    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG_FILE_OUT}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Generating API documentation with Doxygen"
+    VERBATIM)
+endif()
 
 # Create a custom target
 add_custom_target(qdmi_docs ALL DEPENDS ${DOXYGEN_OUTPUT_DIR}/html/index.html)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -87,7 +87,13 @@ set(PROJECT_LOGO "mqss_logo.svg")
 # DOXYGEN_INPUT_DIRS.
 configure_file(${DOXYGEN_CONFIG_FILE_IN} ${DOXYGEN_CONFIG_FILE_OUT} @ONLY)
 
-# Create a custom command to run Doxygen
+# Create a custom command to run Doxygen. If we build from source the binary
+# does not exist yet, so we need to set it
+if(${DOXYGEN_EXECUTABLE} STREQUAL "DOXYGEN_EXECUTABLE-NOTFOUND")
+  set(DOXYGEN_EXECUTABLE ${doxygen_BINARY_DIR}/bin/doxygen)
+  message(STATUS "Setting doxygen binary manually to ${DOXYGEN_EXECUTABLE}")
+endif()
+
 add_custom_command(
   OUTPUT ${DOXYGEN_OUTPUT_DIR}/html/index.html
   DEPENDS ${DOXYGEN_INPUT_FILES}
@@ -97,6 +103,7 @@ add_custom_command(
           ${CMAKE_CURRENT_SOURCE_DIR}/style.css
           ${CMAKE_SOURCE_DIR}/README.md
           ${CMAKE_SOURCE_DIR}/.github/support.md
+          doxygen # Run only after the doxygen target has been done
   COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG_FILE_OUT}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Generating API documentation with Doxygen"


### PR DESCRIPTION
Closes: #146 

This is a preliminary workaround to get the manual installation of `doxygen` working.
I'm not sure if the line
```
target_compile_features(doxygen PUBLIC cxx_std_17)
```
is necessary; it seemed to have no effect, so I moved the c standard definition down.
Also, I chose to compare against `${DOXYGEN_EXECUTABLE}` as in one debugging session `${DOXYGEN_FOUND}` was true but the executable was not found.