### PR TITLE
📝 GitHub community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,47 @@
+name: 🐛 Bug report
+description: Something is not working correctly.
+title: "🐛 <title>"
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        **Thank you for wanting to report a bug for this project!**
+
+        ⚠ Verify first your issue is not [already reported on
+        GitHub](https://github.com/Munich-Quantum-Software-Stack/QDMI/search?q=is%3Aissue&type=issues).
+
+        If you have general questions, please consider [starting a
+        discussion](https://github.com/Munich-Quantum-Software-Stack/QDMI/discussions).
+  - type: textarea
+    attributes:
+      label: Environment information
+      description: >-
+        Please provide information about your environment. For example, OS, C++ compiler, QDMI
+        version etc.
+      placeholder: |
+        - OS:
+        - C++ compiler:
+        - QDMI version:
+        - Additional environment information:
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+  - type: textarea
+    attributes:
+      label: How to Reproduce
+      description: Please provide steps to reproduce this bug.
+      placeholder: |
+        1. Get package from '...'
+        2. Then run '...'
+        3. An error occurs.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,31 @@
+name: ✨ Feature request
+description: Suggest an idea
+title: "✨ <title>"
+body:
+  - type: markdown
+    attributes:
+      value: >
+        **Thank you for wanting to suggest a feature for this project!**
+
+        ⚠ Verify first your idea is not [already requested on
+        GitHub](https://github.com/Munich-Quantum-Software-Stack/QDMI/search?q=is%3Aissue&type=issues).
+
+  - type: textarea
+    attributes:
+      label: What's the problem this feature will solve?
+      description: >-
+        What are you trying to do that you are unable to achieve as it currently stands?
+      placeholder: >-
+        I'm trying to do X and I'm missing feature Y for this to be easily achievable.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like
+      description: >
+        Clear and concise description of what you want to happen.
+      placeholder: >-
+        When I do X, I want to achieve Y in a situation when Z.
+    validations:
+      required: true

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,104 @@
+# Contributing
+
+Thank you for your interest in contributing to this project. We value contributions from people with
+all levels of experience. In particular, if this is your first pull request, not everything has to
+be perfect. We will guide you through the process.
+
+We use GitHub to [host code](https://github.com/Munich-Quantum-Software-Stack/QDMI), to
+[track issues and feature requests](https://github.com/Munich-Quantum-Software-Stack/QDMI/issues),
+as well as accept [pull requests](https://github.com/Munich-Quantum-Software-Stack/QDMI/pulls). See
+<https://docs.github.com/en/get-started/quickstart> for a general introduction to working with
+GitHub and contributing to projects.
+
+## Types of Contributions
+
+You can contribute in several ways:
+
+- 🐛 Report Bugs : Report bugs at <https://github.com/Munich-Quantum-Software-Stack/QDMI/issues>
+  using the _🐛 Bug report_ issue template. Please make sure to fill out all relevant information in
+  the respective issue form.
+
+- 🐛 Fix Bugs : Look through the
+  [GitHub Issues](https://github.com/Munich-Quantum-Software-Stack/QDMI/issues) for bugs. Anything
+  tagged with "bug" is open to whoever wants to try to fix it.
+
+- ✨ Propose New Features : Propose new features at
+  <https://github.com/Munich-Quantum-Software-Stack/QDMI/issues> using the _✨ Feature request_
+  issue template. Please make sure to fill out all relevant information in the respective issue
+  form.
+
+- ✨ Implement New Features : Look through the
+  [GitHub Issues](https://github.com/Munich-Quantum-Software-Stack/QDMI/issues) for features.
+  Anything tagged with "feature" or "enhancement" is open to whoever wants to implement it. We
+  highly appreciate external contributions to the project.
+
+- 📝 Write Documentation : QDMI could always use some more documentation, and we appreciate any help
+  with that.
+
+## Get Started 🎉
+
+Ready to contribute? Check out the
+[Development Guide](https://munich-quantum-software-stack.github.io/QDMI/md_docs_2guide.html) to set
+up QDMI for local development and learn about the style guidelines and conventions used throughout
+the project.
+
+We value contributions from people with all levels of experience. In particular, if this is your
+first PR, not everything has to be perfect. We will guide you through the PR process. Nevertheless,
+please try to follow the guidelines below as well as you can to help make the PR process quick and
+smooth.
+
+## Core Guidelines
+
+- ["Commit early and push often"](https://www.worklytics.co/blog/commit-early-push-often).
+- Write meaningful commit messages, preferably using [gitmoji](https://gitmoji.dev) for additional
+  context.
+- Focus on a single feature or bug at a time and only touch relevant files. Split multiple features
+  into separate contributions.
+- Add tests for new features to ensure they work as intended. Document new features appropriately.
+- Add tests for bug fixes to demonstrate that the bug has been resolved.
+- Document your code thoroughly and ensure it is readable.
+- Keep your code clean by removing debug statements, leftover comments, and unrelated code.
+- Check your code for style and linting errors before committing.
+- Follow the project's coding standards and conventions.
+- Be open to feedback and willing to make necessary changes based on code reviews.
+
+## Pull Request Workflow
+
+- Create PRs early. It is ok to create work-in-progress PRs. You may mark these as draft PRs on
+  GitHub.
+- Describe your PR with a descriptive title, reference any related issues by including the issue
+  number in the PR description, and add a comprehensive description of the changes. Follow the
+  provided PR template and do not delete any sections, except for the issue reference if your PR is
+  not related to any issue.
+- Whenever a PR is created or updated, several workflows on all supported platforms are executed.
+  These workflows ensure that the project still builds, all tests pass, the code is properly
+  formatted, and no new linting errors are introduced. Your PR must pass all these continuous
+  integration (CI) checks before it can be merged.
+- Once your PR is ready, change it from a draft PR to a regular PR and request a review from one of
+  the project maintainers. Only request a review once you are done with your changes and the PR is
+  ready to be reviewed. If you are unsure whether your PR is ready, ask in the PR comments. If you
+  are a first-time contributor, request a review from one of the maintainers by mentioning them in a
+  comment on the PR.
+- If your PR gets a "Changes requested" review, address the feedback and update your PR by pushing
+  to the same branch. Do not close the PR and open a new one. Respond to review comments on the PR
+  (e.g., with "done 👍" or "done in @<commit>") to let the reviewer know that you have addressed the
+  feedback. Note that reviewers do not get a notification if you just react to the review comment
+  with an emoji. Write a comment to notify the reviewer. Do not resolve the review comments
+  yourself. The reviewer will mark the comments as resolved once they are satisfied with the
+  changes.
+- Be sure to re-request a review once you have made changes after a code review so that maintainers
+  know that the requests have been addressed.
+- No need to squash commits before merging; we usually squash them to keep the history clean. We
+  only merge without squashing if the commit history is clean and meaningful. Avoid rebasing or
+  force-pushing your PR branch before merging, as it complicates reviews. You can rebase or clean up
+  commits after addressing all review comments if desired.
+
+---
+
+This document was inspired by and partially adapted from
+
+- <https://github.com/cda-tum/mqt-core/blob/main/.github/contributing.md>
+- <https://matplotlib.org/stable/devel/coding_guide.html>
+- <https://opensource.creativecommons.org/contributing-code/pr-guidelines/>
+- <https://yeoman.io/contributing/pull-request.html>
+- <https://github.com/scikit-build/scikit-build>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant
+motivation and context. List any dependencies that are required for this change.
+
+Fixes #(issue) <!--- Replace (issue) with the issue number that is fixed by this pull request. -->
+
+## Checklist:
+
+<!---
+This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
+-->
+
+- [ ] The pull request only contains commits that are related to it.
+- [ ] I have added appropriate tests and documentation.
+- [ ] I have made sure all CI jobs on GitHub pass.
+- [ ] The pull request introduces no new warnings and follows the project's style guidelines.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
 
   # Check for spelling
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.30.3
     hooks:
       - id: typos
 


### PR DESCRIPTION
This PR adds a couple of community health files to the repository. Specifically, it adds a contributing guide, which is inspired by https://mqt.readthedocs.io/projects/core/en/latest/contributing.html
It also adds two issue templates and a pull request template.

Fixes #155 