### PR TITLE
🐛 Fix Device Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ clients compiled against a different minor or major version.
 
 ### Added
 
+- 🔥 Remove example device implementation in C ([#169]) ([\@ystade])
 - 📝 Add changelog and upgrade guide ([#160]) ([\@ystade], [\@burgholzer])
 - 🚸 Support querying of job properties incl. previously set parameters values ([#160]) ([\@ystade])
 - 🚸 Add new authentication options to `QDMI_SESSION_PARAMETER` and `QDMI_DEVICE_SESSION_PARAMETER`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ clients compiled against a different minor or major version.
 
 ### Added
 
-- 🔥 Remove example device implementation in C ([#169]) ([\@ystade])
 - 📝 Add changelog and upgrade guide ([#160]) ([\@ystade], [\@burgholzer])
 - 🚸 Support querying of job properties incl. previously set parameters values ([#160]) ([\@ystade])
 - 🚸 Add new authentication options to `QDMI_SESSION_PARAMETER` and `QDMI_DEVICE_SESSION_PARAMETER`
@@ -29,6 +28,10 @@ clients compiled against a different minor or major version.
   authentication options ([#160]) ([\@ystade], [\@burgholzer])
 - 🚸 Change order of `QDMI_JOB_STATUS` enum values to better reflect job cycle ([#160]) ([\@ystade])
 - 🚚 Rename `QDMI_SITE_PROPERTY_ID` to `QDMI_SITE_PROPERTY_INDEX` ([#160]) ([\@ystade])
+
+### Removed
+
+- 🔥 Remove example device implementation in C ([#169]) ([\@ystade])
 
 ## [1.1.0] - 2025-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#169]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/169
 [#160]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/160
 
 <!-- Contributor -->

--- a/templates/device/src/my_device.cpp
+++ b/templates/device/src/my_device.cpp
@@ -54,16 +54,16 @@ struct MY_QDMI_Device_Session_impl_d {};
 struct MY_QDMI_Device_Job_impl_d {};
 
 /**
- * @brief Implementation of the MY_QDMI_Device_Site structure.
+ * @brief Implementation of the MY_QDMI_Site structure.
  * @details This structure can, e.g., be used to store the site id.
  */
-struct MY_QDMI_Device_Site_impl_d {};
+struct MY_QDMI_Site_impl_d {};
 
 /**
- * @brief Implementation of the MY_QDMI_Device_Operation structure.
+ * @brief Implementation of the MY_QDMI_Operation structure.
  * @details This structure can, e.g., be used to store the operation id.
  */
-struct MY_QDMI_Device_Operation_impl_d {};
+struct MY_QDMI_Operation_impl_d {};
 
 int MY_QDMI_device_initialize() { return QDMI_ERROR_NOTIMPLEMENTED; }
 


### PR DESCRIPTION
## Description

There was a leftover in the device template from older QDMI versions in the definition of sites and operations as mentioned in #169 . This is fixed by this PR.

Fixes #169 

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
