### PR TITLE
✨ Report the Scope of an Operation

### DIFF
--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -227,3 +227,22 @@ the same enumeration, each with a different prefix. It would also not be possibl
 know about all the different values of the enumeration. Additionally, when linking all devices
 statically into the driver, the name-shifted header for each device must be included. If each device
 would define the enumerations anew, this would lead to a compile-time error.
+
+## Why are there different kinds of sites? {#rationale-site-types}
+
+Originally, QDMI only defined a single kind of site, which was used to represent a location that can
+potentially hold a qubit. Already from the start, we intentionally avoided using the term `Qubit` to
+refer to their location, as on some devices, e.g., neutral atom-based ones, a site must not
+necessarily hold an atom representing the qubit. Hence, a site is more general than a qubit and can
+represent any kind of location that can hold a qubit, such as a superconducting qubit, a neutral
+atom, or a trapped ion. However, when extending the QDMI support for neutral atom-based devices, we
+realized that this was not general enough. These devices offer _global_ operations that execute on
+multiple atoms within a given zone simultaneously. In particular, these global operations cannot be
+executed on individual atoms but on all atoms within a zone at once. Consequently, we had to equip
+QDMI such that it is capable of reporting operation properties with respect to zones and not only
+individual qubit positions. To this end, we introduced the concept of _zone sites_ that represent a
+spatial zone. These have the same type as regular sites, i.e., @ref QDMI_Site, but are used to
+represent a zone instead of a single qubit position. Hence, they can be used in the function @ref
+QDMI_device_query_operation_property as parameter to query data like fidelity or duration of global
+operations specific to a zone. This allows QDMI to represent the capabilities of neutral atom-based
+devices while keeping the interface consistent with the existing site concept.

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -244,5 +244,7 @@ individual qubit positions. To this end, we introduced the concept of _zone site
 spatial zone. These have the same type as regular sites, i.e., @ref QDMI_Site, but are used to
 represent a zone instead of a single qubit position. Hence, they can be used in the function @ref
 QDMI_device_query_operation_property as parameter to query data like fidelity or duration of global
-operations specific to a zone. This allows QDMI to represent the capabilities of neutral atom-based
-devices while keeping the interface consistent with the existing site concept.
+operations specific to a zone. The function @ref QDMI_device_query_device_property will return a
+list of all, i.e., regular and zone sites, for the property @ref QDMI_DEVICE_PROPERTY_SITES.
+Overall, these modifications allow QDMI to represent the capabilities of neutral atom-based devices
+while keeping the interface consistent with the existing site concept.

--- a/examples/device/device.cpp
+++ b/examples/device/device.cpp
@@ -829,9 +829,6 @@ int CXX_QDMI_device_session_query_operation_property(
   ADD_STRING_PROPERTY(QDMI_OPERATION_PROPERTY_NAME,
                       OPERATION_PROPERTIES.at(operation).first.c_str(), prop,
                       size, value, size_ret)
-  // all operations of this example device are considered local
-  ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_GLOBAL, bool, false, prop,
-                            size, value, size_ret)
   if (operation == CXX_DEVICE_OPERATIONS[3]) {
     if (sites != nullptr && num_sites != 2) {
       return QDMI_ERROR_INVALIDARGUMENT;

--- a/examples/device/device.cpp
+++ b/examples/device/device.cpp
@@ -829,6 +829,9 @@ int CXX_QDMI_device_session_query_operation_property(
   ADD_STRING_PROPERTY(QDMI_OPERATION_PROPERTY_NAME,
                       OPERATION_PROPERTIES.at(operation).first.c_str(), prop,
                       size, value, size_ret)
+  // all operations of this example device are considered local
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_GLOBAL, bool, false, prop,
+                            size, value, size_ret)
   if (operation == CXX_DEVICE_OPERATIONS[3]) {
     if (sites != nullptr && num_sites != 2) {
       return QDMI_ERROR_INVALIDARGUMENT;
@@ -837,9 +840,6 @@ int CXX_QDMI_device_session_query_operation_property(
                               prop, size, value, size_ret)
     ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_DURATION, double,
                               OPERATION_PROPERTIES.at(operation).second, prop,
-                              size, value, size_ret)
-    // all operations of this example device are considered local
-    ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_GLOBAL, bool, false, prop,
                               size, value, size_ret)
     if (sites == nullptr) {
       ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_QUBITSNUM, size_t, 2,

--- a/examples/device/device.cpp
+++ b/examples/device/device.cpp
@@ -835,9 +835,11 @@ int CXX_QDMI_device_session_query_operation_property(
     }
     ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_PARAMETERSNUM, size_t, 0,
                               prop, size, value, size_ret)
-
     ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_DURATION, double,
                               OPERATION_PROPERTIES.at(operation).second, prop,
+                              size, value, size_ret)
+    // all operations of this example device are considered local
+    ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_GLOBAL, bool, false, prop,
                               size, value, size_ret)
     if (sites == nullptr) {
       ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_QUBITSNUM, size_t, 2,

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -514,14 +514,12 @@ enum QDMI_OPERATION_PROPERTY_T {
   /// `double` The fidelity of an operation.
   QDMI_OPERATION_PROPERTY_FIDELITY = 4,
   /**
-   * @brief @ref QDMI_Operation_Scope The scope of the operation.
-   * @details The scope of an operation indicates whether the operation
-   * executes on individual sites or on all sites this operation can be applied
-   * to.
-   * @note This property is mainly required for neutral atom devices that offer
-   * global operations in addition to local operations.
+   * @brief `bool` An operation is global if it acts on all sites
+   * simultaneously. the operation is applicable to.
+   * @note This property is mainly relevant for neutral atom devices that can
+   * perform operations on all sites at once, e.g., by global laser pulses.
    */
-  QDMI_OPERATION_PROPERTY_SCOPE = 5,
+  QDMI_OPERATION_PROPERTY_GLOBAL = 5,
   /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
@@ -875,26 +873,6 @@ enum QDMI_DEVICE_PULSE_SUPPORT_LEVEL_T {
 
 /// Pulse support level type.
 typedef enum QDMI_DEVICE_PULSE_SUPPORT_LEVEL_T QDMI_Device_Pulse_Support_Level;
-
-/// The scope of an operation, e.g., local on a site or global on all sites.
-enum QDMI_OPERATION_SCOPE_T {
-  /**
-   * @brief The operation is local, i.e., it acts on individual sites.
-   * @details If the gate is a n-qubit gate, it acts exactly on the n sites
-   * that are specified in the program.
-   */
-  QDMI_OPERATION_SCOPE_LOCAL = 0,
-  /**
-   * @brief The operation is global, i.e., it acts on all sites the operation is
-   * applicable to.
-   * @note This scope is mainly used for neutral atom devices that can
-   * perform operations on all sites at once, e.g., global laser pulses.
-   */
-  QDMI_OPERATION_SCOPE_GLOBAL = 1
-};
-
-/// Operation's scope type.
-typedef enum QDMI_OPERATION_SCOPE_T QDMI_Operation_Scope;
 
 // NOLINTEND(performance-enum-size, modernize-use-using)
 

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -513,6 +513,15 @@ enum QDMI_OPERATION_PROPERTY_T {
   /// `double` The fidelity of an operation.
   QDMI_OPERATION_PROPERTY_FIDELITY = 4,
   /**
+   * @brief @ref QDMI_Operation_Scope The scope of the operation.
+   * @details The scope of an operation indicates whether the operation
+   * executes on individual sites or on all sites within the region of
+   * the operation.
+   * @note This property is mainly required for neutral atom devices that offer
+   * apart from local operations also global operations.
+   */
+  QDMI_OPERATION_PROPERTY_SCOPE = 5,
+  /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
    * function parameters.
@@ -520,7 +529,7 @@ enum QDMI_OPERATION_PROPERTY_T {
    * @attention This value must remain the last regular member of the enum
    * besides the custom members and must be updated when new members are added.
    */
-  QDMI_OPERATION_PROPERTY_MAX = 5,
+  QDMI_OPERATION_PROPERTY_MAX = 6,
   /**
    * @brief This enum value is reserved for a custom property.
    * @details The device defines the meaning and the type of this property.
@@ -860,11 +869,31 @@ enum QDMI_DEVICE_PULSE_SUPPORT_LEVEL_T {
    * @details This means that the device can execute pulse-level instructions on
    * both the sites and channels of the device.
    */
-  QDMI_DEVICE_PULSE_SUPPORT_LEVEL_SITEANDCHANNEL = 3,
+  QDMI_DEVICE_PULSE_SUPPORT_LEVEL_SITEANDCHANNEL = 3
 };
 
 /// Pulse support level type.
 typedef enum QDMI_DEVICE_PULSE_SUPPORT_LEVEL_T QDMI_Device_Pulse_Support_Level;
+
+/// The scope of an operation, e.g., local on a site or global on all sites.
+enum QDMI_OPERATION_SCOPE_T {
+  /**
+   * @brief The operation is local, i.e., it acts on individual sites.
+   * @details If the gate is a n-qubit gate, it acts exactly on the n sites
+   * that are specified in the program.
+   */
+  QDMI_OPERATION_SCOPE_LOCAL = 0,
+  /**
+   * @brief The operation is global, i.e., it acts on all sites in the
+   * operation's region.
+   * @note This scope is mainly used for neutral atom devices that can
+   * perform operations on all sites at once, e.g., global laser pulses.
+   */
+  QDMI_OPERATION_SCOPE_GLOBAL = 1
+};
+
+/// Operation's scope type.
+typedef enum QDMI_OPERATION_SCOPE_T QDMI_Operation_Scope;
 
 // NOLINTEND(performance-enum-size, modernize-use-using)
 

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -469,6 +469,62 @@ enum QDMI_SITE_PROPERTY_T {
    */
   QDMI_SITE_PROPERTY_ZCOORDINATE = 6,
   /**
+   * @brief `bool` Whether the site is a zone.
+   * @details A zone is a site that has a spatial extent, i.e., it is not
+   * just a point in space as a regular site. These kind of sites, namely zones,
+   * are required to adequately represent global operations that act on all
+   * qubits within a certain area, i.e., a zone.
+   * @note Zones are typically used in neutral atom devices, where the atoms are
+   * arranged in a 2D or 3D lattice, and operations can be applied to all
+   * atoms within a certain zone.
+   * @note This property defaults to `false`, i.e., if a device reports @ref
+   * QDMI_ERROR_NOTSUPPORTED for this property, it is assumed that the site is
+   * a regular site and not a zone.
+   * @see QDMI_SITE_PROPERTY_XEXTENT
+   * @see QDMI_SITE_PROPERTY_YEXTENT
+   * @see QDMI_SITE_PROPERTY_ZEXTENT
+   */
+  QDMI_SITE_PROPERTY_ISZONE = 7,
+  /**
+   * @brief `uint64_t` The x-extent of a zone.
+   * @details The x-extent is the size of the zone in the x-direction.
+   * @note This property is a length value and must be interpreted in the way
+   * specified by the @ref QDMI_DEVICE_PROPERTY_LENGTHUNIT and @ref
+   * QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR properties.
+   * @note This property is mainly required for neutral atom devices to
+   * report the extent of zones, see @ref QDMI_SITE_PROPERTY_ISZONE.
+   * @note If the site is not a zone, this property must return @ref
+   * QDMI_ERROR_NOTSUPPORTED.
+   * @see QDMI_DEVICE_PROPERTY_LENGTHUNIT
+   */
+  QDMI_SITE_PROPERTY_XEXTENT = 8,
+  /**
+   * @brief `uint64_t` The y-extent of a zone.
+   * @details The y-extent is the size of the zone in the y-direction.
+   * @note This property is a length value and must be interpreted in the way
+   * specified by the @ref QDMI_DEVICE_PROPERTY_LENGTHUNIT and @ref
+   * QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR properties.
+   * @note This property is mainly required for neutral atom devices to
+   * report the extent of zones, see @ref QDMI_SITE_PROPERTY_ISZONE.
+   * @note If the site is not a zone, this property must return @ref
+   * QDMI_ERROR_NOTSUPPORTED.
+   * @see QDMI_DEVICE_PROPERTY_LENGTHUNIT
+   */
+  QDMI_SITE_PROPERTY_YEXTENT = 9,
+  /**
+   * @brief `uint64_t` The z-extent of a zone.
+   * @details The z-extent is the size of the zone in the z-direction.
+   * @note This property is a length value and must be interpreted in the way
+   * specified by the @ref QDMI_DEVICE_PROPERTY_LENGTHUNIT and @ref
+   * QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR properties.
+   * @note This property is mainly required for neutral atom devices to
+   * report the extent of zones, see @ref QDMI_SITE_PROPERTY_ISZONE.
+   * @note If the site is not a zone, this property must return @ref
+   * QDMI_ERROR_NOTSUPPORTED.
+   * @see QDMI_DEVICE_PROPERTY_LENGTHUNIT
+   */
+  QDMI_SITE_PROPERTY_ZEXTENT = 10,
+  /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
    * function parameters.
@@ -476,7 +532,7 @@ enum QDMI_SITE_PROPERTY_T {
    * @attention This value must remain the last regular member of the enum
    * besides the custom members and must be updated when new members are added.
    */
-  QDMI_SITE_PROPERTY_MAX = 7,
+  QDMI_SITE_PROPERTY_MAX = 11,
   /**
    * @brief This enum value is reserved for a custom property.
    * @details The device defines the meaning and the type of this property.
@@ -514,13 +570,6 @@ enum QDMI_OPERATION_PROPERTY_T {
   /// `double` The fidelity of an operation.
   QDMI_OPERATION_PROPERTY_FIDELITY = 4,
   /**
-   * @brief `bool` An operation is global if it acts on all sites
-   * the operation is applicable to simultaneously.
-   * @note This property is mainly relevant for neutral atom devices that can
-   * perform operations on all sites at once, e.g., by global laser pulses.
-   */
-  QDMI_OPERATION_PROPERTY_GLOBAL = 5,
-  /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
    * function parameters.
@@ -528,7 +577,7 @@ enum QDMI_OPERATION_PROPERTY_T {
    * @attention This value must remain the last regular member of the enum
    * besides the custom members and must be updated when new members are added.
    */
-  QDMI_OPERATION_PROPERTY_MAX = 6,
+  QDMI_OPERATION_PROPERTY_MAX = 5,
   /**
    * @brief This enum value is reserved for a custom property.
    * @details The device defines the meaning and the type of this property.

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -290,6 +290,11 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @details The returned @ref QDMI_Site handles may be used to query site
    * and operation properties. The list need not be sorted based on the @ref
    * QDMI_SITE_PROPERTY_INDEX.
+   * @par
+   * The list returned by this property contains all sites of the device, i.e.,
+   * regular and zone sites (see @ref QDMI_SITE_PROPERTY_ISZONE). To filter out
+   * regular or zone sites, use the function @ref
+   * QDMI_device_query_site_property.
    */
   QDMI_DEVICE_PROPERTY_SITES = 5,
   /**

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -515,8 +515,8 @@ enum QDMI_OPERATION_PROPERTY_T {
   /**
    * @brief @ref QDMI_Operation_Scope The scope of the operation.
    * @details The scope of an operation indicates whether the operation
-   * executes on individual sites or on all sites within the region of
-   * the operation.
+   * executes on individual sites or on all sites this operation can be applied
+   * to.
    * @note This property is mainly required for neutral atom devices that offer
    * apart from local operations also global operations.
    */
@@ -884,8 +884,8 @@ enum QDMI_OPERATION_SCOPE_T {
    */
   QDMI_OPERATION_SCOPE_LOCAL = 0,
   /**
-   * @brief The operation is global, i.e., it acts on all sites in the
-   * operation's region.
+   * @brief The operation is global, i.e., it acts on all sites the operation is
+   * applicable to.
    * @note This scope is mainly used for neutral atom devices that can
    * perform operations on all sites at once, e.g., global laser pulses.
    */

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -515,7 +515,7 @@ enum QDMI_OPERATION_PROPERTY_T {
   QDMI_OPERATION_PROPERTY_FIDELITY = 4,
   /**
    * @brief `bool` An operation is global if it acts on all sites
-   * simultaneously. the operation is applicable to.
+   * the operation is applicable to simultaneously.
    * @note This property is mainly relevant for neutral atom devices that can
    * perform operations on all sites at once, e.g., by global laser pulses.
    */

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -486,8 +486,7 @@ enum QDMI_SITE_PROPERTY_T {
    */
   QDMI_SITE_PROPERTY_ISZONE = 7,
   /**
-   * @brief `uint64_t` The x-extent of a zone.
-   * @details The x-extent is the size of the zone in the x-direction.
+   * @brief `uint64_t` The extent of a zone along the X-axis.
    * @note This property is a length value and must be interpreted in the way
    * specified by the @ref QDMI_DEVICE_PROPERTY_LENGTHUNIT and @ref
    * QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR properties.
@@ -499,8 +498,7 @@ enum QDMI_SITE_PROPERTY_T {
    */
   QDMI_SITE_PROPERTY_XEXTENT = 8,
   /**
-   * @brief `uint64_t` The y-extent of a zone.
-   * @details The y-extent is the size of the zone in the y-direction.
+   * @brief `uint64_t` The extent of a zone along the Y-axis.
    * @note This property is a length value and must be interpreted in the way
    * specified by the @ref QDMI_DEVICE_PROPERTY_LENGTHUNIT and @ref
    * QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR properties.
@@ -512,8 +510,7 @@ enum QDMI_SITE_PROPERTY_T {
    */
   QDMI_SITE_PROPERTY_YEXTENT = 9,
   /**
-   * @brief `uint64_t` The z-extent of a zone.
-   * @details The z-extent is the size of the zone in the z-direction.
+   * @brief `uint64_t` The extent of a zone along the Z-axis.
    * @note This property is a length value and must be interpreted in the way
    * specified by the @ref QDMI_DEVICE_PROPERTY_LENGTHUNIT and @ref
    * QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR properties.

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -869,7 +869,7 @@ enum QDMI_DEVICE_PULSE_SUPPORT_LEVEL_T {
    * @details This means that the device can execute pulse-level instructions on
    * both the sites and channels of the device.
    */
-  QDMI_DEVICE_PULSE_SUPPORT_LEVEL_SITEANDCHANNEL = 3
+  QDMI_DEVICE_PULSE_SUPPORT_LEVEL_SITEANDCHANNEL = 3,
 };
 
 /// Pulse support level type.

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -518,7 +518,7 @@ enum QDMI_OPERATION_PROPERTY_T {
    * executes on individual sites or on all sites this operation can be applied
    * to.
    * @note This property is mainly required for neutral atom devices that offer
-   * apart from local operations also global operations.
+   * global operations in addition to local operations.
    */
   QDMI_OPERATION_PROPERTY_SCOPE = 5,
   /**

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -167,14 +167,6 @@ TEST_P(QDMIImplementationTest, QueryGatePropertiesForEachGate) {
                   device, op, 0, nullptr, 0, nullptr,
                   QDMI_OPERATION_PROPERTY_MAX, 0, nullptr, nullptr),
               QDMI_ERROR_INVALIDARGUMENT);
-    // the example device only offers local operations
-    bool global = true;
-    EXPECT_EQ(
-        QDMI_device_query_operation_property(device, op, 0, nullptr, 0, nullptr,
-                                             QDMI_OPERATION_PROPERTY_GLOBAL,
-                                             sizeof(bool), &global, nullptr),
-        QDMI_SUCCESS);
-    EXPECT_FALSE(global);
 
     // The example devices do not support custom properties
     EXPECT_EQ(QDMI_device_query_operation_property(
@@ -216,6 +208,10 @@ TEST_P(QDMIImplementationTest, QuerySiteProperties) {
     const auto t2 = fomac.get_site_t2(site);
     EXPECT_GT(t2, 0);
 
+    // the example device only offers regular sites
+    EXPECT_EQ(QDMI_device_query_site_property(
+                  device, site, QDMI_SITE_PROPERTY_ISZONE, 0, nullptr, nullptr),
+              QDMI_SUCCESS);
     // The example devices do not support neutral atom-specific properties
     EXPECT_EQ(QDMI_device_query_site_property(device, site,
                                               QDMI_SITE_PROPERTY_XCOORDINATE, 0,
@@ -227,6 +223,18 @@ TEST_P(QDMIImplementationTest, QuerySiteProperties) {
               QDMI_ERROR_NOTSUPPORTED);
     EXPECT_EQ(QDMI_device_query_site_property(device, site,
                                               QDMI_SITE_PROPERTY_ZCOORDINATE, 0,
+                                              nullptr, nullptr),
+              QDMI_ERROR_NOTSUPPORTED);
+    EXPECT_EQ(QDMI_device_query_site_property(device, site,
+                                              QDMI_SITE_PROPERTY_XEXTENT, 0,
+                                              nullptr, nullptr),
+              QDMI_ERROR_NOTSUPPORTED);
+    EXPECT_EQ(QDMI_device_query_site_property(device, site,
+                                              QDMI_SITE_PROPERTY_YEXTENT, 0,
+                                              nullptr, nullptr),
+              QDMI_ERROR_NOTSUPPORTED);
+    EXPECT_EQ(QDMI_device_query_site_property(device, site,
+                                              QDMI_SITE_PROPERTY_ZEXTENT, 0,
                                               nullptr, nullptr),
               QDMI_ERROR_NOTSUPPORTED);
 

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -173,7 +173,7 @@ TEST_P(QDMIImplementationTest, QueryGatePropertiesForEachGate) {
         QDMI_device_query_operation_property(device, op, 0, nullptr, 0, nullptr,
                                              QDMI_OPERATION_PROPERTY_GLOBAL,
                                              sizeof(bool), &global, nullptr),
-        QDMI_ERROR_NOTSUPPORTED);
+        QDMI_SUCCESS);
     EXPECT_FALSE(global);
 
     // The example devices do not support custom properties

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -168,6 +168,12 @@ TEST_P(QDMIImplementationTest, QueryGatePropertiesForEachGate) {
                   QDMI_OPERATION_PROPERTY_MAX, 0, nullptr, nullptr),
               QDMI_ERROR_INVALIDARGUMENT);
 
+    // The example devices do not support neutral atom-specific properties
+    EXPECT_EQ(QDMI_device_query_operation_property(
+                  device, op, 0, nullptr, 0, nullptr,
+                  QDMI_OPERATION_PROPERTY_SCOPE, 0, nullptr, nullptr),
+              QDMI_ERROR_NOTSUPPORTED);
+
     // The example devices do not support custom properties
     EXPECT_EQ(QDMI_device_query_operation_property(
                   device, op, 0, nullptr, 0, nullptr,

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -167,12 +167,14 @@ TEST_P(QDMIImplementationTest, QueryGatePropertiesForEachGate) {
                   device, op, 0, nullptr, 0, nullptr,
                   QDMI_OPERATION_PROPERTY_MAX, 0, nullptr, nullptr),
               QDMI_ERROR_INVALIDARGUMENT);
-
-    // The example devices do not support neutral atom-specific properties
-    EXPECT_EQ(QDMI_device_query_operation_property(
-                  device, op, 0, nullptr, 0, nullptr,
-                  QDMI_OPERATION_PROPERTY_SCOPE, 0, nullptr, nullptr),
-              QDMI_ERROR_NOTSUPPORTED);
+    // the example device only offers local operations
+    bool global = true;
+    EXPECT_EQ(
+        QDMI_device_query_operation_property(device, op, 0, nullptr, 0, nullptr,
+                                             QDMI_OPERATION_PROPERTY_GLOBAL,
+                                             sizeof(bool), &global, nullptr),
+        QDMI_ERROR_NOTSUPPORTED);
+    EXPECT_FALSE(global);
 
     // The example devices do not support custom properties
     EXPECT_EQ(QDMI_device_query_operation_property(

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -211,7 +211,7 @@ TEST_P(QDMIImplementationTest, QuerySiteProperties) {
     // the example device only offers regular sites
     EXPECT_EQ(QDMI_device_query_site_property(
                   device, site, QDMI_SITE_PROPERTY_ISZONE, 0, nullptr, nullptr),
-              QDMI_SUCCESS);
+              QDMI_ERROR_NOTSUPPORTED);
     // The example devices do not support neutral atom-specific properties
     EXPECT_EQ(QDMI_device_query_site_property(device, site,
                                               QDMI_SITE_PROPERTY_XCOORDINATE, 0,


### PR DESCRIPTION
## Description

On NA devices, operations on qubits can be global, i.e., a laser illuminates all atoms within an array, inducing an operation on all illuminated atoms. For compilation, it is important to know, whether an operation can only be applied to all atoms simultaneously or whether it can be addressed to individual qubits.

To this end, the concept of sites is generalised. The sites used previously remain sites and are called "regular sites". Additionally, to those this PR introduces "zone sites". Those sites report being a zone by a corresponding property. Additionally they define a spatial extent.

A global operation acting on a zone represented by a `QDMI_Site` object `interaction_zone` would then report `QDMI_ERROR_UNSUPPORTED` for all other sites if queried through the function `QDMI_device_query_operation_property`.

In conclusion, determining whether an operation is global on some zone is a two-fold process:
1. One finds the site(s) and operation can be applied to.
2. If the found site(s) are zones, i.e., the property `QDMI_SITE_PROPERTY_ISZONE` is `true`, then the operation is global.

Since this PR is concerned with NA-specific support of QDMI, it also contributes to #184.

## Checklist:

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
