### PR TITLE
✨ Introducing Duration Unit and Reporting Shuttling Speed

### DIFF
--- a/examples/device/device.cpp
+++ b/examples/device/device.cpp
@@ -808,9 +808,9 @@ int CXX_QDMI_device_session_query_site_property(CXX_QDMI_Device_Session session,
                             size, value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_MODULEINDEX, uint64_t, 0, prop,
                             size, value, size_ret)
-  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T1, uint64_t, 1000U, prop, size,
-                            value, size_ret)
-  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T2, uint64_t, 100000U, prop,
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T1, uint64_t, 100000U, prop,
+                            size, value, size_ret)
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T2, uint64_t, 10000000U, prop,
                             size, value, size_ret)
   return QDMI_ERROR_NOTSUPPORTED;
 } /// [DOXYGEN FUNCTION END]

--- a/examples/device/device.cpp
+++ b/examples/device/device.cpp
@@ -808,9 +808,9 @@ int CXX_QDMI_device_session_query_site_property(CXX_QDMI_Device_Session session,
                             size, value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_MODULEINDEX, uint64_t, 0, prop,
                             size, value, size_ret)
-  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T1, uint64_t, 100000U, prop,
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T1, uint64_t, 1000000U, prop,
                             size, value, size_ret)
-  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T2, uint64_t, 10000000U, prop,
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T2, uint64_t, 100000000U, prop,
                             size, value, size_ret)
   return QDMI_ERROR_NOTSUPPORTED;
 } /// [DOXYGEN FUNCTION END]

--- a/examples/device/device.cpp
+++ b/examples/device/device.cpp
@@ -177,10 +177,10 @@ constexpr std::array<const CXX_QDMI_Site_impl_d *, 20>
 const std::unordered_map<const CXX_QDMI_Operation_impl_d *,
                          std::pair<std::string, double>>
     OPERATION_PROPERTIES = {
-        {CXX_DEVICE_OPERATIONS[0], {"rx", 0.01}},
-        {CXX_DEVICE_OPERATIONS[1], {"ry", 0.01}},
-        {CXX_DEVICE_OPERATIONS[2], {"rz", 0.01}},
-        {CXX_DEVICE_OPERATIONS[3], {"cx", 0.1}},
+        {CXX_DEVICE_OPERATIONS[0], {"rx", 10}},
+        {CXX_DEVICE_OPERATIONS[1], {"ry", 10}},
+        {CXX_DEVICE_OPERATIONS[2], {"rz", 10}},
+        {CXX_DEVICE_OPERATIONS[3], {"cx", 10}},
 };
 
 struct CXX_QDMI_Pair_hash {
@@ -782,6 +782,11 @@ int CXX_QDMI_device_session_query_device_property(
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR, double, 1.0,
                             prop, size, value, size_ret)
 
+  ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_DURATIONUNIT, "us", prop, size,
+                      value, size_ret)
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR, double,
+                            0.001, prop, size, value, size_ret)
+
   return QDMI_ERROR_NOTSUPPORTED;
 } /// [DOXYGEN FUNCTION END]
 
@@ -803,10 +808,10 @@ int CXX_QDMI_device_session_query_site_property(CXX_QDMI_Device_Session session,
                             size, value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_MODULEINDEX, uint64_t, 0, prop,
                             size, value, size_ret)
-  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T1, double, 1000.0, prop, size,
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T1, uint64_t, 1000U, prop, size,
                             value, size_ret)
-  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T2, double, 100000.0, prop, size,
-                            value, size_ret)
+  ADD_SINGLE_VALUE_PROPERTY(QDMI_SITE_PROPERTY_T2, uint64_t, 100000U, prop,
+                            size, value, size_ret)
   return QDMI_ERROR_NOTSUPPORTED;
 } /// [DOXYGEN FUNCTION END]
 
@@ -837,7 +842,7 @@ int CXX_QDMI_device_session_query_operation_property(
     }
     ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_PARAMETERSNUM, size_t, 0,
                               prop, size, value, size_ret)
-    ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_DURATION, double,
+    ADD_SINGLE_VALUE_PROPERTY(QDMI_OPERATION_PROPERTY_DURATION, uint64_t,
                               OPERATION_PROPERTIES.at(operation).second, prop,
                               size, value, size_ret)
     if (sites == nullptr) {

--- a/examples/device/device.cpp
+++ b/examples/device/device.cpp
@@ -175,7 +175,7 @@ constexpr std::array<const CXX_QDMI_Site_impl_d *, 20>
 // clang-format on
 
 const std::unordered_map<const CXX_QDMI_Operation_impl_d *,
-                         std::pair<std::string, double>>
+                         std::pair<std::string, uint64_t>>
     OPERATION_PROPERTIES = {
         {CXX_DEVICE_OPERATIONS[0], {"rx", 10}},
         {CXX_DEVICE_OPERATIONS[1], {"ry", 10}},

--- a/examples/device/device.cpp
+++ b/examples/device/device.cpp
@@ -180,7 +180,7 @@ const std::unordered_map<const CXX_QDMI_Operation_impl_d *,
         {CXX_DEVICE_OPERATIONS[0], {"rx", 10}},
         {CXX_DEVICE_OPERATIONS[1], {"ry", 10}},
         {CXX_DEVICE_OPERATIONS[2], {"rz", 10}},
-        {CXX_DEVICE_OPERATIONS[3], {"cx", 10}},
+        {CXX_DEVICE_OPERATIONS[3], {"cx", 100}},
 };
 
 struct CXX_QDMI_Pair_hash {

--- a/examples/fomac/example_fomac.cpp
+++ b/examples/fomac/example_fomac.cpp
@@ -166,20 +166,45 @@ auto FoMaC::get_site_id(QDMI_Site site) const -> uint64_t {
   return site_id;
 }
 
+auto FoMaC::get_us_scale_factor() const -> double {
+  size_t size = 0;
+  int ret = QDMI_device_query_device_property(
+      device, QDMI_DEVICE_PROPERTY_DURATIONUNIT, 0, nullptr, &size);
+  throw_if_error(ret, "Failed to retrieve the device's duration unit size.");
+  std::string unit(size - 1, '\0');
+  ret = QDMI_device_query_device_property(
+      device, QDMI_DEVICE_PROPERTY_DURATIONUNIT, unit.size() + 1, unit.data(),
+      nullptr);
+  throw_if_error(ret, "Failed to retrieve the device's duration unit.");
+  double scale_factor = 0.0;
+  ret = QDMI_device_query_device_property(
+      device, QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR, sizeof(double),
+      &scale_factor, nullptr);
+  throw_if_error(ret, "Failed to query the duration scale factor");
+  if (unit == "ms") {
+    scale_factor /= 1000;
+  } else if (unit == "ns") {
+    scale_factor *= 1000;
+  } else if (unit != "us") {
+    throw std::runtime_error("Unrecognized unit: " + unit);
+  }
+  return scale_factor;
+}
+
 auto FoMaC::get_site_t1(QDMI_Site site) const -> double {
-  double t1 = 0;
+  uint64_t t1 = 0;
   const int ret = QDMI_device_query_site_property(
       device, site, QDMI_SITE_PROPERTY_T1, sizeof(double), &t1, nullptr);
   throw_if_error(ret, "Failed to query the T1 time");
-  return t1;
+  return t1 * get_us_scale_factor();
 }
 
 auto FoMaC::get_site_t2(QDMI_Site site) const -> double {
-  double t2 = 0;
+  uint64_t t2 = 0;
   const int ret = QDMI_device_query_site_property(
       device, site, QDMI_SITE_PROPERTY_T2, sizeof(double), &t2, nullptr);
   throw_if_error(ret, "Failed to query the T2 time");
-  return t2;
+  return t2 * get_us_scale_factor();
 }
 
 auto FoMaC::get_operands_num(const QDMI_Operation &op) const -> size_t {

--- a/examples/fomac/example_fomac.cpp
+++ b/examples/fomac/example_fomac.cpp
@@ -194,7 +194,7 @@ auto FoMaC::get_us_scale_factor() const -> double {
 auto FoMaC::get_site_t1(QDMI_Site site) const -> double {
   uint64_t t1 = 0;
   const int ret = QDMI_device_query_site_property(
-      device, site, QDMI_SITE_PROPERTY_T1, sizeof(double), &t1, nullptr);
+      device, site, QDMI_SITE_PROPERTY_T1, sizeof(uint64_t), &t1, nullptr);
   throw_if_error(ret, "Failed to query the T1 time");
   return static_cast<double>(t1) * get_us_scale_factor();
 }
@@ -202,7 +202,7 @@ auto FoMaC::get_site_t1(QDMI_Site site) const -> double {
 auto FoMaC::get_site_t2(QDMI_Site site) const -> double {
   uint64_t t2 = 0;
   const int ret = QDMI_device_query_site_property(
-      device, site, QDMI_SITE_PROPERTY_T2, sizeof(double), &t2, nullptr);
+      device, site, QDMI_SITE_PROPERTY_T2, sizeof(uint64_t), &t2, nullptr);
   throw_if_error(ret, "Failed to query the T2 time");
   return static_cast<double>(t2) * get_us_scale_factor();
 }

--- a/examples/fomac/example_fomac.cpp
+++ b/examples/fomac/example_fomac.cpp
@@ -196,7 +196,7 @@ auto FoMaC::get_site_t1(QDMI_Site site) const -> double {
   const int ret = QDMI_device_query_site_property(
       device, site, QDMI_SITE_PROPERTY_T1, sizeof(double), &t1, nullptr);
   throw_if_error(ret, "Failed to query the T1 time");
-  return t1 * get_us_scale_factor();
+  return static_cast<double>(t1) * get_us_scale_factor();
 }
 
 auto FoMaC::get_site_t2(QDMI_Site site) const -> double {
@@ -204,7 +204,7 @@ auto FoMaC::get_site_t2(QDMI_Site site) const -> double {
   const int ret = QDMI_device_query_site_property(
       device, site, QDMI_SITE_PROPERTY_T2, sizeof(double), &t2, nullptr);
   throw_if_error(ret, "Failed to query the T2 time");
-  return t2 * get_us_scale_factor();
+  return static_cast<double>(t2) * get_us_scale_factor();
 }
 
 auto FoMaC::get_operands_num(const QDMI_Operation &op) const -> size_t {

--- a/examples/fomac/example_fomac.hpp
+++ b/examples/fomac/example_fomac.hpp
@@ -40,6 +40,8 @@ private:
 
   static auto throw_if_error(int status, const std::string &message) -> void;
 
+  [[nodiscard]] auto get_us_scale_factor() const -> double;
+
 public:
   explicit FoMaC(QDMI_Device dev) : device(dev) {}
 

--- a/include/qdmi/client.h
+++ b/include/qdmi/client.h
@@ -476,9 +476,9 @@ int QDMI_device_query_device_property(QDMI_Device device,
  * }
  *
  * // Query the property.
- * double t1;
+ * uint64_t t1;
  * QDMI_device_query_site_property(
- *   device, site, QDMI_SITE_PROPERTY_T1, sizeof(double), &t1, nullptr);
+ *   device, site, QDMI_SITE_PROPERTY_T1, sizeof(uint64_t), &t1, nullptr);
  * ```
  *
  * @remark @ref QDMI_Site handles may be queried via @ref

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -356,7 +356,7 @@ enum QDMI_DEVICE_PROPERTY_T {
   QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR = 11,
   /**
    * @brief `char*` (string) The duration unit used by the device.
-   * @details This property must be a known SI unit, e.g., "s", "ms" or "ns".
+   * @details This property must be a known SI unit, e.g., "ms", "us" or "ns".
    * All length values must first be multiplied with the value returned by @ref
    * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR and then interpreted in the unit
    * set for this property here.

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -355,6 +355,24 @@ enum QDMI_DEVICE_PROPERTY_T {
    */
   QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR = 11,
   /**
+   * @brief `char*` (string) The duration unit used by the device.
+   * @details This property must be a known SI unit, e.g., "s", "ms" or "ns".
+   * All length values must first be multiplied with the value returned by @ref
+   * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR and then interpreted in the unit
+   * set for this property here.
+   * @note If the device returns any duration value, this property must be set.
+   */
+  QDMI_DEVICE_PROPERTY_DURATIONUNIT = 12,
+  /**
+   * @brief `double` A factor applied to all duration values.
+   * @details This value must be multiplied with all duration values returned by
+   * the device before it can be interpreted in the unit returned by  @ref
+   * QDMI_DEVICE_PROPERTY_DURATIONUNIT.
+   * @note If this property is @ref QDMI_ERROR_NOTSUPPORTED, a default value of
+   * `1.0` is assumed.
+   */
+  QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR = 13,
+  /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
    * function parameters.
@@ -362,7 +380,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @attention This value must remain the last regular member of the enum
    * besides the custom members and must be updated when new members are added.
    */
-  QDMI_DEVICE_PROPERTY_MAX = 12,
+  QDMI_DEVICE_PROPERTY_MAX = 14,
   /**
    * @brief This enum value is reserved for a custom property.
    * @details The device defines the meaning and the type of this property.

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -635,6 +635,23 @@ enum QDMI_OPERATION_PROPERTY_T {
    */
   QDMI_OPERATION_PROPERTY_BLOCKINGRADIUS = 6,
   /**
+   * @brief `uint64_t` The mean shuttling speed of the operation.
+   * @details The mean shuttling speed is the average speed at which qubits can
+   * be moved during the operation.
+   * @note This property is mainly required for neutral atom devices where atoms
+   * representing qubits can be moved to different sites.
+   * @note This property is a velocity value, i.e., it is a length divided by a
+   * duration. The value must be multiplied by the value returned by @ref
+   * QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR and divided by the value
+   * returned by @ref QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR to obtain the
+   * velocity in the unit specified by the @ref
+   * QDMI_DEVICE_PROPERTY_LENGTHUNIT divided by @ref
+   * QDMI_DEVICE_PROPERTY_DURATIONUNIT.
+   * @see QDMI_DEVICE_PROPERTY_LENGTHUNIT
+   * @see QDMI_DEVICE_PROPERTY_DURATIONUNIT
+   */
+  QDMI_OPERATION_PROPERTY_MEANSHUTTLINGSPEED = 7,
+  /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
    * function parameters.
@@ -642,7 +659,7 @@ enum QDMI_OPERATION_PROPERTY_T {
    * @attention This value must remain the last regular member of the enum
    * besides the custom members and must be updated when new members are added.
    */
-  QDMI_OPERATION_PROPERTY_MAX = 7,
+  QDMI_OPERATION_PROPERTY_MAX = 8,
   /**
    * @brief This enum value is reserved for a custom property.
    * @details The device defines the meaning and the type of this property.

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -355,21 +355,22 @@ enum QDMI_DEVICE_PROPERTY_T {
    */
   QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR = 11,
   /**
-   * @brief `char*` (string) The duration unit used by the device.
-   * @details This property must be a known SI unit, e.g., "ms", "us" or "ns".
-   * All length values must first be multiplied with the value returned by @ref
-   * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR and then interpreted in the unit
-   * set for this property here.
-   * @note If the device returns any duration value, this property must be set.
+   * @brief `char*` (string) The duration unit reported by the device.
+   * @details The device implementation must report a known SI unit (e.g., "ms",
+   * "us", or "ns") for this property. A client querying a duration value must
+   * first scale it using @ref QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR. The
+   * resulting value is then interpreted in the unit specified by this property.
+   * @note If the device reports any duration values, this property must be set.
    */
   QDMI_DEVICE_PROPERTY_DURATIONUNIT = 12,
   /**
-   * @brief `double` A factor applied to all duration values.
-   * @details This value must be multiplied with all duration values returned by
-   * the device before it can be interpreted in the unit returned by  @ref
-   * QDMI_DEVICE_PROPERTY_DURATIONUNIT.
-   * @note If this property is @ref QDMI_ERROR_NOTSUPPORTED, a default value of
-   * `1.0` is assumed.
+   * @brief `double` A scale factor for all duration values.
+   * @details The device implementation reports this scale factor. A client must
+   * multiply any raw duration value received from the device by this factor to
+   * obtain the physical duration. The unit of the physical duration is given by
+   * @ref QDMI_DEVICE_PROPERTY_DURATIONUNIT.
+   * @note If querying this property returns @ref QDMI_ERROR_NOTSUPPORTED, a
+   * client should assume a default value of `1.0`.
    */
   QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR = 13,
   /**
@@ -441,19 +442,25 @@ enum QDMI_SITE_PROPERTY_T {
    */
   QDMI_SITE_PROPERTY_INDEX = 0,
   /**
-   * @brief `uint64_t` The T1 time of a site.
-   * @note This property is a duration value and must be interpreted in the way
-   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONUNIT and @ref
-   * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR properties.
+   * @brief `uint64_t` The raw, unscaled T1 time of a site.
+   * @details To obtain the physical T1 time, a client must scale the raw value
+   * of this property. The physical T1 time is calculated as: `raw_value *
+   * scale_factor`, where `scale_factor` is the value of the
+   * @ref QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR property. The resulting value
+   * is in units of @ref QDMI_DEVICE_PROPERTY_DURATIONUNIT.
    * @see QDMI_DEVICE_PROPERTY_DURATIONUNIT
+   * @see QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR
    */
   QDMI_SITE_PROPERTY_T1 = 1,
   /**
-   * @brief `uint64_t` The T2 time of a site.
-   * @note This property is a duration value and must be interpreted in the way
-   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONUNIT and @ref
-   * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR properties.
+   * @brief `uint64_t` The raw, unscaled T2 time of a site.
+   * @details To obtain the physical T2 time, a client must scale the raw value
+   * of this property. The physical T2 time is calculated as: `raw_value *
+   * scale_factor`, where `scale_factor` is the value of the
+   * @ref QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR property. The resulting value
+   * is in units of @ref QDMI_DEVICE_PROPERTY_DURATIONUNIT.
    * @see QDMI_DEVICE_PROPERTY_DURATIONUNIT
+   * @see QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR
    */
   QDMI_SITE_PROPERTY_T2 = 2,
   /**
@@ -613,11 +620,14 @@ enum QDMI_OPERATION_PROPERTY_T {
   /// `size_t` The number of floating point parameters the operation takes.
   QDMI_OPERATION_PROPERTY_PARAMETERSNUM = 2,
   /**
-   * `uint64_t` The duration of an operation.
-   * @note This property is a duration value and must be interpreted in the way
-   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONUNIT and @ref
-   * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR properties.
+   * @brief `uint64_t` The raw, unscaled duration of an operation.
+   * @details To obtain the physical duration, a client must scale the raw value
+   * of this property. The physical duration is calculated as: `raw_value *
+   * scale_factor`, where `scale_factor` is the value of the
+   * @ref QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR property. The resulting value
+   * is in units of @ref QDMI_DEVICE_PROPERTY_DURATIONUNIT.
    * @see QDMI_DEVICE_PROPERTY_DURATIONUNIT
+   * @see QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR
    */
   QDMI_OPERATION_PROPERTY_DURATION = 3,
   /// `double` The fidelity of an operation.
@@ -653,20 +663,21 @@ enum QDMI_OPERATION_PROPERTY_T {
    */
   QDMI_OPERATION_PROPERTY_BLOCKINGRADIUS = 6,
   /**
-   * @brief `uint64_t` The mean shuttling speed of the operation.
-   * @details The mean shuttling speed is the average speed at which qubits can
-   * be moved during the operation.
+   * @brief `uint64_t` The raw, unscaled mean shuttling speed of an operation.
+   * @details To obtain the physical speed, a client must scale the raw value of
+   * this property. The physical speed is calculated as: `raw_value *
+   * length_scale_factor / duration_scale_factor`. The `length_scale_factor` is
+   * the value of @ref QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR and the
+   * `duration_scale_factor` is the value of @ref
+   * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR. The resulting value is in units
+   * of @ref QDMI_DEVICE_PROPERTY_LENGTHUNIT per @ref
+   * QDMI_DEVICE_PROPERTY_DURATIONUNIT.
    * @note This property is mainly required for neutral atom devices where atoms
    * representing qubits can be moved to different sites.
-   * @note This property is a velocity value, i.e., it is a length divided by a
-   * duration. The value must be multiplied by the value returned by @ref
-   * QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR and divided by the value
-   * returned by @ref QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR to obtain the
-   * velocity in the unit specified by the @ref
-   * QDMI_DEVICE_PROPERTY_LENGTHUNIT divided by @ref
-   * QDMI_DEVICE_PROPERTY_DURATIONUNIT.
    * @see QDMI_DEVICE_PROPERTY_LENGTHUNIT
+   * @see QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR
    * @see QDMI_DEVICE_PROPERTY_DURATIONUNIT
+   * @see QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR
    */
   QDMI_OPERATION_PROPERTY_MEANSHUTTLINGSPEED = 7,
   /**

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -443,7 +443,7 @@ enum QDMI_SITE_PROPERTY_T {
   /**
    * @brief `uint64_t` The T1 time of a site.
    * @note This property is a duration value and must be interpreted in the way
-   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONHUNIT and @ref
+   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONUNIT and @ref
    * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR properties.
    * @see QDMI_DEVICE_PROPERTY_DURATIONUNIT
    */
@@ -451,7 +451,7 @@ enum QDMI_SITE_PROPERTY_T {
   /**
    * @brief `uint64_t` The T2 time of a site.
    * @note This property is a duration value and must be interpreted in the way
-   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONHUNIT and @ref
+   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONUNIT and @ref
    * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR properties.
    * @see QDMI_DEVICE_PROPERTY_DURATIONUNIT
    */
@@ -615,7 +615,7 @@ enum QDMI_OPERATION_PROPERTY_T {
   /**
    * `uint64_t` The duration of an operation.
    * @note This property is a duration value and must be interpreted in the way
-   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONHUNIT and @ref
+   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONUNIT and @ref
    * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR properties.
    * @see QDMI_DEVICE_PROPERTY_DURATIONUNIT
    */

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -440,9 +440,21 @@ enum QDMI_SITE_PROPERTY_T {
    * address the sites in a program.
    */
   QDMI_SITE_PROPERTY_INDEX = 0,
-  /// `double` The T1 time of a site in µs.
+  /**
+   * @brief `uint64_t` The T1 time of a site.
+   * @note This property is a duration value and must be interpreted in the way
+   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONHUNIT and @ref
+   * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR properties.
+   * @see QDMI_DEVICE_PROPERTY_DURATIONUNIT
+   */
   QDMI_SITE_PROPERTY_T1 = 1,
-  /// `double` The T2 time of a site in µs.
+  /**
+   * @brief `uint64_t` The T2 time of a site.
+   * @note This property is a duration value and must be interpreted in the way
+   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONHUNIT and @ref
+   * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR properties.
+   * @see QDMI_DEVICE_PROPERTY_DURATIONUNIT
+   */
   QDMI_SITE_PROPERTY_T2 = 2,
   /**
    * `char*` (string) The name of a site, e.g., another identifier of the site
@@ -600,7 +612,13 @@ enum QDMI_OPERATION_PROPERTY_T {
   QDMI_OPERATION_PROPERTY_QUBITSNUM = 1,
   /// `size_t` The number of floating point parameters the operation takes.
   QDMI_OPERATION_PROPERTY_PARAMETERSNUM = 2,
-  /// `double` The duration of an operation in µs.
+  /**
+   * `uint64_t` The duration of an operation.
+   * @note This property is a duration value and must be interpreted in the way
+   * specified by the @ref QDMI_DEVICE_PROPERTY_DURATIONHUNIT and @ref
+   * QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR properties.
+   * @see QDMI_DEVICE_PROPERTY_DURATIONUNIT
+   */
   QDMI_OPERATION_PROPERTY_DURATION = 3,
   /// `double` The fidelity of an operation.
   QDMI_OPERATION_PROPERTY_FIDELITY = 4,

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -312,16 +312,33 @@ TEST_P(QDMIImplementationTest, QueryDeviceProperties) {
   EXPECT_EQ(QDMI_device_query_device_property(
                 device, QDMI_DEVICE_PROPERTY_LENGTHUNIT, 0, nullptr, &size),
             QDMI_SUCCESS);
-  std::string unit(size - 1, '\0');
-  EXPECT_EQ(
-      QDMI_device_query_device_property(device, QDMI_DEVICE_PROPERTY_LENGTHUNIT,
-                                        unit.size() + 1, unit.data(), nullptr),
-      QDMI_SUCCESS);
-  EXPECT_THAT(unit, testing::AnyOf("mm", "um", "nm"));
+  std::string length_unit(size - 1, '\0');
+  EXPECT_EQ(QDMI_device_query_device_property(
+                device, QDMI_DEVICE_PROPERTY_LENGTHUNIT, length_unit.size() + 1,
+                length_unit.data(), nullptr),
+            QDMI_SUCCESS);
+  EXPECT_THAT(length_unit, testing::AnyOf("mm", "um", "nm"));
   double scale_factor = 0.0;
   EXPECT_EQ(QDMI_device_query_device_property(
                 device, QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR, sizeof(double),
                 &scale_factor, nullptr),
+            QDMI_SUCCESS);
+  EXPECT_GE(scale_factor, 0.0);
+  // Query the duration unit of the device
+  size = 0;
+  EXPECT_EQ(QDMI_device_query_device_property(
+                device, QDMI_DEVICE_PROPERTY_DURATIONUNIT, 0, nullptr, &size),
+            QDMI_SUCCESS);
+  std::string duration_unit(size - 1, '\0');
+  EXPECT_EQ(QDMI_device_query_device_property(
+                device, QDMI_DEVICE_PROPERTY_DURATIONUNIT,
+                duration_unit.size() + 1, duration_unit.data(), nullptr),
+            QDMI_SUCCESS);
+  EXPECT_THAT(duration_unit, testing::AnyOf("ms", "us", "ns"));
+  scale_factor = 0.0;
+  EXPECT_EQ(QDMI_device_query_device_property(
+                device, QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR,
+                sizeof(double), &scale_factor, nullptr),
             QDMI_SUCCESS);
   EXPECT_GE(scale_factor, 0.0);
 

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -173,6 +173,11 @@ TEST_P(QDMIImplementationTest, QueryGatePropertiesForEachGate) {
                   device, op, 0, nullptr, 0, nullptr,
                   QDMI_OPERATION_PROPERTY_BLOCKINGRADIUS, 0, nullptr, nullptr),
               QDMI_ERROR_NOTSUPPORTED);
+    EXPECT_EQ(QDMI_device_query_operation_property(
+                  device, op, 0, nullptr, 0, nullptr,
+                  QDMI_OPERATION_PROPERTY_MEANSHUTTLINGSPEED, 0, nullptr,
+                  nullptr),
+              QDMI_ERROR_NOTSUPPORTED);
 
     // The MAX property is not a valid value for any device
     EXPECT_EQ(QDMI_device_query_operation_property(

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -324,23 +324,6 @@ TEST_P(QDMIImplementationTest, QueryDeviceProperties) {
                 &scale_factor, nullptr),
             QDMI_SUCCESS);
   EXPECT_GE(scale_factor, 0.0);
-  // Query the duration unit of the device
-  size = 0;
-  EXPECT_EQ(QDMI_device_query_device_property(
-                device, QDMI_DEVICE_PROPERTY_DURATIONUNIT, 0, nullptr, &size),
-            QDMI_SUCCESS);
-  std::string duration_unit(size - 1, '\0');
-  EXPECT_EQ(QDMI_device_query_device_property(
-                device, QDMI_DEVICE_PROPERTY_DURATIONUNIT,
-                duration_unit.size() + 1, duration_unit.data(), nullptr),
-            QDMI_SUCCESS);
-  EXPECT_THAT(duration_unit, testing::AnyOf("ms", "us", "ns"));
-  scale_factor = 0.0;
-  EXPECT_EQ(QDMI_device_query_device_property(
-                device, QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR,
-                sizeof(double), &scale_factor, nullptr),
-            QDMI_SUCCESS);
-  EXPECT_GE(scale_factor, 0.0);
 
   // The MAX property is not a valid value for any device.
   EXPECT_EQ(QDMI_device_query_device_property(device, QDMI_DEVICE_PROPERTY_MAX,

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -122,7 +122,7 @@ TEST_P(QDMIImplementationTest, QueryGatePropertiesForEachGate) {
       param = dis(gen);
     }
 
-    double duration = 0;
+    uint64_t duration = 0;
     double fidelity = 0;
     if (gate_num_qubits == 1) {
       for (const auto &site : sites) {
@@ -130,7 +130,7 @@ TEST_P(QDMIImplementationTest, QueryGatePropertiesForEachGate) {
         EXPECT_EQ(QDMI_device_query_operation_property(
                       device, op, gate_num_qubits, site_arr.data(),
                       gate_num_params, params.data(),
-                      QDMI_OPERATION_PROPERTY_DURATION, sizeof(double),
+                      QDMI_OPERATION_PROPERTY_DURATION, sizeof(uint64_t),
                       &duration, nullptr),
                   QDMI_SUCCESS)
             << "Failed to query duration for operation " << name;
@@ -149,7 +149,7 @@ TEST_P(QDMIImplementationTest, QueryGatePropertiesForEachGate) {
         EXPECT_EQ(QDMI_device_query_operation_property(
                       device, op, gate_num_qubits, site_arr.data(),
                       gate_num_params, params.data(),
-                      QDMI_OPERATION_PROPERTY_DURATION, sizeof(double),
+                      QDMI_OPERATION_PROPERTY_DURATION, sizeof(uint64_t),
                       &duration, nullptr),
                   QDMI_SUCCESS)
             << "Failed to query duration for gate " << op;


### PR DESCRIPTION
## Description

This PR adds properties to report the duration unit used by the device, similarly to the length unit introduced in #198.

On top, it adds the feature to report the shuttling speed requested in #191.

Fixes #191

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
