### PR TITLE
🐛 Fix Install Instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ clients compiled against a different minor or major version.
 
 ### Fixed
 
+- 🐛 Add target `qdmi_project_warnings` to the export targets ([#214]) ([\@ystade])
 - 🐛 Fix definitions of `QDMI_Site`and `QDMI_Operation` in device template ([#169]) ([\@ystade])
 
 ### Removed
@@ -60,6 +61,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#214]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/214
 [#211]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/211
 [#210]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/210
 [#209]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/209

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ endif()
 # Installation instructions for the main library
 if(QDMI_INSTALL)
   install(
-    TARGETS qdmi
+    TARGETS qdmi qdmi_project_warnings
     EXPORT ${PROJECT_NAME}-targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
## Description

When using QDMI and linking against QDMI one also needs to have QDMI's project warning's target available. Howver, that was not added to the export target which this PR does now.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
