### PR TITLE
Fix bug in example tool

### DIFF
--- a/examples/tool/example_tool.cpp
+++ b/examples/tool/example_tool.cpp
@@ -67,22 +67,29 @@ std::string Tool::compile(const std::string &qasm_string) {
     throw std::invalid_argument(
         "The device does not provide enough qubits for the circuit.");
   }
+
   // Choose an arbitrary edge for the two qubits
   const auto edge = fomac.get_coupling_map().front();
-  std::stringstream from;
-  from << "qreg q[" << num_qubits << "];";
-  std::stringstream to;
-  to << "qreg q[" << fomac.get_qubits_num() << "];";
-  auto result = replace_all_occurrences(qasm_string, from.str(), to.str());
-  from.clear();
-  from << "q[0]";
-  to.clear();
-  to << "q[" << edge.first << "]";
-  result = replace_all_occurrences(result, from.str(), to.str());
-  from.clear();
-  from << "q[1]";
-  to.clear();
-  to << "q[" << edge.second << "]";
-  result = replace_all_occurrences(result, from.str(), to.str());
+  auto id0 = fomac.get_site_id(edge.first);
+  auto id1 = fomac.get_site_id(edge.second);
+
+  std::string from_decl = (std::stringstream() << "qreg q[" << num_qubits << "];").str();
+  std::string to_decl = (std::stringstream() << "qreg q[" << fomac.get_qubits_num() << "];").str();
+  auto result = replace_all_occurrences(qasm_string, from_decl, to_decl);
+
+  /// The aux-trick is needed for the edge case that id1 == 1 which would later on be replaced by 
+  /// id2 if directly replaced here.
+  std::string from_q0 = "q[0]";
+  std::string to_aux = (std::stringstream() << "q[aux]").str();
+  result = replace_all_occurrences(result, from_q0, to_aux);
+
+  std::string from_q1 = "q[1]";
+  std::string to_q1 = (std::stringstream() << "q[" << id1 << "]").str();
+  result = replace_all_occurrences(result, from_q1, to_q1);
+
+  std::string from_aux = "q[aux]";
+  std::string to_q0 = (std::stringstream() << "q[" << id0 << "]").str();
+  result = replace_all_occurrences(result, from_aux, to_q0);
+
   return result;
 }

--- a/examples/tool/example_tool.cpp
+++ b/examples/tool/example_tool.cpp
@@ -73,25 +73,25 @@ std::string Tool::compile(const std::string &qasm_string) {
   auto id0 = fomac.get_site_id(edge.first);
   auto id1 = fomac.get_site_id(edge.second);
 
-  std::string from_decl =
+  std::string const from_decl =
       (std::stringstream() << "qreg q[" << num_qubits << "];").str();
-  std::string to_decl =
+  std::string const to_decl =
       (std::stringstream() << "qreg q[" << fomac.get_qubits_num() << "];")
           .str();
   auto result = replace_all_occurrences(qasm_string, from_decl, to_decl);
 
   /// The aux-trick is needed for the edge case that id1 == 1 which would later
   /// on be replaced by id2 if directly replaced here.
-  std::string from_q0 = "q[0]";
-  std::string to_aux = (std::stringstream() << "q[aux]").str();
+  std::string const from_q0 = "q[0]";
+  std::string const to_aux = (std::stringstream() << "q[aux]").str();
   result = replace_all_occurrences(result, from_q0, to_aux);
 
-  std::string from_q1 = "q[1]";
-  std::string to_q1 = (std::stringstream() << "q[" << id1 << "]").str();
+  std::string const from_q1 = "q[1]";
+  std::string const to_q1 = (std::stringstream() << "q[" << id1 << "]").str();
   result = replace_all_occurrences(result, from_q1, to_q1);
 
-  std::string from_aux = "q[aux]";
-  std::string to_q0 = (std::stringstream() << "q[" << id0 << "]").str();
+  std::string const from_aux = "q[aux]";
+  std::string const to_q0 = (std::stringstream() << "q[" << id0 << "]").str();
   result = replace_all_occurrences(result, from_aux, to_q0);
 
   return result;

--- a/examples/tool/example_tool.cpp
+++ b/examples/tool/example_tool.cpp
@@ -73,12 +73,15 @@ std::string Tool::compile(const std::string &qasm_string) {
   auto id0 = fomac.get_site_id(edge.first);
   auto id1 = fomac.get_site_id(edge.second);
 
-  std::string from_decl = (std::stringstream() << "qreg q[" << num_qubits << "];").str();
-  std::string to_decl = (std::stringstream() << "qreg q[" << fomac.get_qubits_num() << "];").str();
+  std::string from_decl =
+      (std::stringstream() << "qreg q[" << num_qubits << "];").str();
+  std::string to_decl =
+      (std::stringstream() << "qreg q[" << fomac.get_qubits_num() << "];")
+          .str();
   auto result = replace_all_occurrences(qasm_string, from_decl, to_decl);
 
-  /// The aux-trick is needed for the edge case that id1 == 1 which would later on be replaced by 
-  /// id2 if directly replaced here.
+  /// The aux-trick is needed for the edge case that id1 == 1 which would later
+  /// on be replaced by id2 if directly replaced here.
   std::string from_q0 = "q[0]";
   std::string to_aux = (std::stringstream() << "q[aux]").str();
   result = replace_all_occurrences(result, from_q0, to_aux);


### PR DESCRIPTION
## Description

There was a bug in `Tool::compile`. The original code could never (correctly) replace the qubits (e.g. `q[0]` by `q[<replaced id>]`), due to two subtle issues

- Clearing the stringstream did not actually empty it (see e.g. `from.clear()`), hence it accumulated garbage preventing the pattern matching to ever match the qubits.
- `edge.first` and `edge.second` are just pointer and hence print to but numbers and not the desired ids of the sites.

This PR fixes those things. There is a test for `Tool::compile` (see `TEST_P(QDMIImplementationTest, ToolCompile)`) but it could not capture this bug because the input and expected output are mostly the same which is replicated by doing (mostly) nothing.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [ ] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
