### PR TITLE
👷🏼 Better support for PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
     with:
       # do not try to build docs in test builds
       cmake-args: "-DBUILD_QDMI_DOCS=OFF -G Ninja"
+    permissions:
+      contents: read
+      id-token: write
 
   linter:
     name: 🇨‌ Lint

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -22,7 +22,8 @@ jobs:
           cmake -S . -B build -DBUILD_QDMI_DOCS=ON
           cmake --build build --target qdmi_docs
           mv build/docs/html/ static
-      - name: Deploy preview 🚀 (for PRs)
+      - name: Deploy preview 🚀 (for PRs; not for forks)
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./static/


### PR DESCRIPTION
## Description

This PR aims to improve the developer experience for PRs from forks, which would previously fail due to a lack of permissions.
The docs preview is now no longer being deployed on PRs from forks.
Some extra permissions are given to the testing workflow. Although I have to say that I am not sure what is going on with codecov. The exact same setup is working nicely over at the MQT.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
