### PR TITLE
✨ Update CMake config and External Dependencies

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -15,11 +15,11 @@ jobs:
         if: github.event.action != 'closed'
         uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1.6.4
         with:
-          version: "1.13.2"
+          version: "1.15.0"
       - name: Install and Build 🔧
         if: github.event.action != 'closed'
         run: |
-          cmake -S . -B build -DBUILD_QDMI_DOCS=ON
+          cmake -S . -B build
           cmake --build build --target qdmi_docs
           mv build/docs/html/ static
       - name: Deploy preview 🚀 (for PRs; not for forks)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ clients compiled against a different minor or major version.
 
 ### Changed
 
+- 📦 Raise the minimum required CMake version to 3.24 ([#250]) ([\@burgholzer])
 - 🔧 Improve library installation setup and header management ([#228]) ([\@burgholzer])
 - 🔧 Set c++ standard target based ([#165]) ([\@ystade])
 - **Breaking**: 🚸 Change order of `QDMI_SESSION_PARAMETER` and `QDMI_DEVICE_SESSION` enum values
@@ -44,6 +45,7 @@ clients compiled against a different minor or major version.
 
 ### Fixed
 
+- 📝 Re-enable FetchContent for doxygen and build docs by default ([#250]) ([\@burgholzer])
 - 🐛 Add target `qdmi_project_warnings` to the export targets ([#214]) ([\@ystade])
 - 🐛 Fix definitions of `QDMI_Site`and `QDMI_Operation` in device template ([#169]) ([\@ystade])
 
@@ -64,6 +66,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#250]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/250
 [#234]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/234
 [#228]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/228
 [#214]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/214

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,7 @@
 # ------------------------------------------------------------------------------
 
 # set required cmake version
-cmake_minimum_required(VERSION 3.19...4.0)
-
+cmake_minimum_required(VERSION 3.24...4.2)
 project(
   qdmi
   LANGUAGES C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,8 @@ option(BUILD_QDMI_TESTS "Also build tests for the QDMI project"
        ${QDMI_MASTER_PROJECT})
 option(BUILD_QDMI_EXAMPLES "Also build examples for the QDMI project"
        ${QDMI_MASTER_PROJECT})
-# Temporarily making this opt-in until getting Doxygen via FetchContent works
-option(BUILD_QDMI_DOCS "Also build documentation for the QDMI project" OFF)
+option(BUILD_QDMI_DOCS "Also build documentation for the QDMI project"
+       ${QDMI_MASTER_PROJECT})
 option(BUILD_QDMI_TEMPLATES "Also build templates for the QDMI project"
        ${QDMI_MASTER_PROJECT})
 

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -57,7 +57,7 @@ if(BUILD_QDMI_TESTS)
       ON
       CACHE BOOL "" FORCE)
   set(GTEST_VERSION
-      1.16.0
+      1.17.0
       CACHE STRING "Google Test version")
   set(GTEST_URL
       https://github.com/google/googletest/archive/refs/tags/v${GTEST_VERSION}.tar.gz
@@ -65,17 +65,9 @@ if(BUILD_QDMI_TESTS)
   set(INSTALL_GTEST
       OFF
       CACHE BOOL "Disable GoogleTest installation")
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
-    FetchContent_Declare(googletest URL ${GTEST_URL} FIND_PACKAGE_ARGS
-                                        ${GTEST_VERSION} NAMES GTest)
-    list(APPEND FETCH_PACKAGES googletest)
-  else()
-    find_package(googletest ${GTEST_VERSION} QUIET NAMES GTest)
-    if(NOT googletest_FOUND)
-      FetchContent_Declare(googletest URL ${GTEST_URL})
-      list(APPEND FETCH_PACKAGES googletest)
-    endif()
-  endif()
+  FetchContent_Declare(googletest URL ${GTEST_URL} FIND_PACKAGE_ARGS
+                                      ${GTEST_VERSION} NAMES GTest)
+  list(APPEND FETCH_PACKAGES googletest)
 endif()
 
 # Make all declared dependencies available.

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -21,59 +21,35 @@ include(CMakeDependentOption)
 set(FETCH_PACKAGES "")
 
 if(BUILD_QDMI_DOCS)
-  # Not using FetchContent here, as the source build of doxygen is currently
-  # broken. See https://github.com/doxygen/doxygen/issues/11416 for further
-  # details.
-  find_package(Doxygen 1.12.0 REQUIRED)
-  # cmake-format: off
-  #  set(DOXYGEN_VERSION
-  #      1.12.0
-  #      CACHE STRING "Doxygen version")
-  #  set(DOXYGEN_REV
-  #      "64dfee0a4b65a4dc3687dfc6b31535a844681ffa"
-  #      CACHE STRING "Doxygen identifier (tag, branch or commit hash)")
-  #  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
-  #    FetchContent_Declare(
-  #      Doxygen
-  #      GIT_REPOSITORY https://github.com/doxygen/doxygen.git
-  #      GIT_TAG ${DOXYGEN_REV}
-  #      FIND_PACKAGE_ARGS ${DOXYGEN_VERSION})
-  #    list(APPEND FETCH_PACKAGES Doxygen)
-  #  else()
-  #    find_package(Doxygen ${DOXYGEN_VERSION} QUIET)
-  #    if(NOT Doxygen_FOUND)
-  #      FetchContent_Declare(
-  #        Doxygen
-  #        GIT_REPOSITORY https://github.com/doxygen/doxygen.git
-  #        GIT_TAG ${DOXYGEN_REV})
-  #      list(APPEND FETCH_PACKAGES Doxygen)
-  #    endif()
-  #  endif()
-  # cmake-format: on
+  set(CMAKE_POLICY_DEFAULT_CMP0116
+      NEW
+      CACHE STRING
+            "Set the default CMP0116 policy to NEW for documentation builds")
+  set(DOXYGEN_VERSION
+      1.15.0
+      CACHE STRING "Doxygen version")
+  set(DOXYGEN_REV
+      "7cca38ba5185457e6d9495bf963d4cdeacebc25a"
+      CACHE STRING "Doxygen identifier (tag, branch or commit hash)")
+  FetchContent_Declare(
+    Doxygen
+    GIT_REPOSITORY https://github.com/doxygen/doxygen.git
+    GIT_TAG ${DOXYGEN_REV}
+    FIND_PACKAGE_ARGS ${DOXYGEN_VERSION})
+  list(APPEND FETCH_PACKAGES Doxygen)
 
   set(DOXYGEN_AWESOME_VERSION
-      1.12.0
+      2.4.1
       CACHE STRING "Doxygen Awesome version")
   set(DOXYGEN_AWESOME_REV
-      "af1d9030b3ffa7b483fa9997a7272fb12af6af4c"
+      "1f3620084ff75734ed192101acf40e9dff01d848"
       CACHE STRING "Doxygen Awesome identifier (tag, branch or commit hash)")
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
-    FetchContent_Declare(
-      doxygen-awesome-css
-      GIT_REPOSITORY https://github.com/jothepro/doxygen-awesome-css.git
-      GIT_TAG ${DOXYGEN_AWESOME_REV}
-      FIND_PACKAGE_ARGS ${DOXYGEN_AWESOME_VERSION})
-    list(APPEND FETCH_PACKAGES doxygen-awesome-css)
-  else()
-    find_package(doxygen-awesome-css ${DOXYGEN_AWESOME_VERSION} QUIET)
-    if(NOT doxygen-awesome-css_FOUND)
-      FetchContent_Declare(
-        doxygen-awesome-css
-        GIT_REPOSITORY https://github.com/jothepro/doxygen-awesome-css.git
-        GIT_TAG ${DOXYGEN_AWESOME_REV})
-      list(APPEND FETCH_PACKAGES doxygen-awesome-css)
-    endif()
-  endif()
+  FetchContent_Declare(
+    doxygen-awesome-css
+    GIT_REPOSITORY https://github.com/jothepro/doxygen-awesome-css.git
+    GIT_TAG ${DOXYGEN_AWESOME_REV}
+    FIND_PACKAGE_ARGS ${DOXYGEN_AWESOME_VERSION})
+  list(APPEND FETCH_PACKAGES doxygen-awesome-css)
 endif()
 
 if(BUILD_QDMI_TESTS)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -90,6 +90,11 @@ set(PROJECT_LOGO "mqss_logo.svg")
 # DOXYGEN_INPUT_DIRS.
 configure_file(${DOXYGEN_CONFIG_FILE_IN} ${DOXYGEN_CONFIG_FILE_OUT} @ONLY)
 
+if(${DOXYGEN_EXECUTABLE} STREQUAL "DOXYGEN_EXECUTABLE-NOTFOUND")
+  set(DOXYGEN_EXECUTABLE ${doxygen_BINARY_DIR}/bin/doxygen)
+  message(STATUS "Setting doxygen binary manually to ${DOXYGEN_EXECUTABLE}")
+endif()
+
 # Create a custom command to run Doxygen
 add_custom_command(
   OUTPUT ${DOXYGEN_OUTPUT_DIR}/html/index.html
@@ -102,6 +107,7 @@ add_custom_command(
           ${CMAKE_SOURCE_DIR}/CHANGELOG.md
           ${CMAKE_SOURCE_DIR}/UPGRADING.md
           ${CMAKE_SOURCE_DIR}/.github/support.md
+          $<IF:$<TARGET_EXISTS:doxygen>,doxygen,>
   COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG_FILE_OUT}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMENT "Generating API documentation with Doxygen"

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -81,7 +81,7 @@ Ready to contribute to QDMI? This guide will help you get started.
 
 ## Working on Source Code
 
-Building the project requires a C compiler supporting _C11_ and a minimum CMake version of _3.19_.
+Building the project requires a C compiler supporting _C11_ and a minimum CMake version of _3.24_.
 The example devices and the tests require a C++ compiler supporting _C++17_.
 
 ### Configure and Build


### PR DESCRIPTION
## Description

This PR updates the general CMake configuration of the project.
It changes the minimum required CMake version to 3.24, which allows simplifying some of the FetchContent usage.
Additionally, it updates all external dependencies, including doxygen, which allows us to fix the long-standing issues observed in #146 and initially tackled in #148.

Fixes #146 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
