### PR TITLE
✨ Add device property `QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS` for efficiently querying the device's supported program formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ _No unreleased changes yet._
   of duration values ([#210]) ([\@ystade], [\@burgholzer])
 - ✨ Add property to efficiently query the applicability of operations to specific sites ([#207])
   ([\@ystade], [\@burgholzer])
+- ✨ Add device property `QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS` for efficiently querying the
+  device's supported program formats ([#252]) ([\@burgholzer])
 - ✨ Add device property `QDMI_DEVICE_PROPERTY_PULSESUPPORT` for querying pulse-level control
   support level ([#181]) ([\@mnfarooqi])
 - 🚸 Add new functions `QDMI_job_query_property` and `QDMI_device_job_query_property` to support
@@ -85,6 +87,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#252]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/252
 [#250]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/250
 [#234]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/234
 [#228]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/228

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -100,6 +100,8 @@ your codebase.
 #### New Properties (Non-Breaking)
 
 - **`QDMI_OPERATION_PROPERTY_SITES`**: Returns the list of sites to which an operation applies
+- **`QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS`**: Returns the list of supported program formats
+  for the device. Devices are highly encouraged to implement support for this property.
 - **`QDMI_DEVICE_PROPERTY_PULSESUPPORT`**: Returns the degree of pulse-level control support using
   the `QDMI_Device_Pulse_Support_Level` enum
   - Devices without pulse support should return `QDMI_DEVICE_PULSE_SUPPORT_LEVEL_NONE`

--- a/examples/device/device.cpp
+++ b/examples/device/device.cpp
@@ -211,6 +211,10 @@ const std::unordered_map<
           {{CXX_DEVICE_SITES[0], CXX_DEVICE_SITES[4]}, 0.95}}},
         // No need to specify single-qubit fidelities here
 };
+
+constexpr std::array SUPPORTED_PROGRAM_FORMATS = {
+    QDMI_PROGRAM_FORMAT_QASM2, QDMI_PROGRAM_FORMAT_QIRBASESTRING,
+    QDMI_PROGRAM_FORMAT_QIRBASEMODULE, QDMI_PROGRAM_FORMAT_CALIBRATION};
 } // namespace
 
 // NOLINTBEGIN(bugprone-macro-parentheses)
@@ -786,6 +790,10 @@ int CXX_QDMI_device_session_query_device_property(
                       value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR, double,
                             0.001, prop, size, value, size_ret)
+
+  ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS,
+                    QDMI_Program_Format, SUPPORTED_PROGRAM_FORMATS, prop, size,
+                    value, size_ret)
 
   return QDMI_ERROR_NOTSUPPORTED;
 } /// [DOXYGEN FUNCTION END]

--- a/examples/fomac/example_fomac.cpp
+++ b/examples/fomac/example_fomac.cpp
@@ -224,3 +224,17 @@ auto FoMaC::get_parameters_num(const QDMI_Operation &op) const -> size_t {
   throw_if_error(ret, "Failed to query the parameter number");
   return parameters_num;
 }
+
+auto FoMaC::get_supported_program_formats() const
+    -> std::vector<QDMI_Program_Format> {
+  size_t size = 0;
+  int ret = QDMI_device_query_device_property(
+      device, QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS, 0, nullptr, &size);
+  throw_if_error(ret, "Failed to query the supported program formats size.");
+  std::vector<QDMI_Program_Format> formats(size / sizeof(QDMI_Program_Format));
+  ret = QDMI_device_query_device_property(
+      device, QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS, size,
+      static_cast<void *>(formats.data()), nullptr);
+  throw_if_error(ret, "Failed to query the supported program formats.");
+  return formats;
+}

--- a/examples/fomac/example_fomac.hpp
+++ b/examples/fomac/example_fomac.hpp
@@ -35,7 +35,6 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <vector>
 
 class FoMaC {
-private:
   QDMI_Device device;
 
   static auto throw_if_error(int status, const std::string &message) -> void;
@@ -65,4 +64,7 @@ public:
 
   [[nodiscard]] auto get_parameters_num(const QDMI_Operation &op) const
       -> size_t;
+
+  [[nodiscard]] auto get_supported_program_formats() const
+      -> std::vector<QDMI_Program_Format>;
 };

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -394,6 +394,14 @@ enum QDMI_DEVICE_PROPERTY_T {
    */
   QDMI_DEVICE_PROPERTY_MINATOMDISTANCE = 14,
   /**
+   * @brief `QDMI_Program_Format*` (@ref QDMI_Program_Format list) The program
+   * formats supported by the device.
+   * @details The returned list contains all program formats that the device
+   * supports for execution. A client can use this information to determine
+   * which program formats can be used when submitting jobs to the device.
+   */
+  QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS = 15,
+  /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
    * function parameters.
@@ -401,7 +409,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @attention This value must remain the last regular member of the enum
    * besides the custom members and must be updated when new members are added.
    */
-  QDMI_DEVICE_PROPERTY_MAX = 15,
+  QDMI_DEVICE_PROPERTY_MAX = 16,
   /**
    * @brief This enum value is reserved for a custom property.
    * @details The device defines the meaning and the type of this property.

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -453,6 +453,16 @@ TEST_P(QDMIImplementationTest, JobLifecycle) {
                                      &supported_format),
               QDMI_SUCCESS);
   }
+
+  const auto fomac = FoMaC(device);
+  const auto formats = fomac.get_supported_program_formats();
+  for (const auto &program_format : formats) {
+    ASSERT_EQ(QDMI_job_set_parameter(job, QDMI_JOB_PARAMETER_PROGRAMFORMAT,
+                                     sizeof(QDMI_Program_Format),
+                                     &program_format),
+              QDMI_SUCCESS);
+  }
+
   constexpr std::array unsupported_formats = {
       QDMI_PROGRAM_FORMAT_QASM3,
       QDMI_PROGRAM_FORMAT_QIRADAPTIVESTRING,


### PR DESCRIPTION
## Description

Adds a new device-level property for conveniently querying the supported program formats of a device.
Previously, this required creating a throwaway `QDMI_Job` and probing `QDMI_(device_)job_set_parameter` (which would error out on job handles that are null).

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
