### PR TITLE
Potential fix for code scanning alert no. 29: Uncontrolled data used in path expression

### DIFF
--- a/examples/driver/qdmi_example_driver.cpp
+++ b/examples/driver/qdmi_example_driver.cpp
@@ -230,14 +230,18 @@ void QDMI_library_load(const std::string &lib_name, const std::string &prefix) {
 }
 
 bool Is_path_allowed(const std::filesystem::path &path) {
-  // Construct the allowlist of canonical allowed directories, skipping any nullptr "HOME" values.
+  // Construct the allowlist of canonical allowed directories, skipping any
+  // nullptr "HOME" values.
   std::vector<std::filesystem::path> allowlist;
-  allowlist.push_back(std::filesystem::canonical(std::filesystem::current_path()));
+  allowlist.push_back(
+      std::filesystem::canonical(std::filesystem::current_path()));
   const char *home_env = std::getenv("HOME");
   if (home_env != nullptr) {
-    // Only add HOME to the allowlist if it is set and points to a valid directory
+    // Only add HOME to the allowlist if it is set and points to a valid
+    // directory
     try {
-      allowlist.push_back(std::filesystem::canonical(std::filesystem::path(home_env)));
+      allowlist.push_back(
+          std::filesystem::canonical(std::filesystem::path(home_env)));
     } catch (const std::filesystem::filesystem_error &) {
       // Ignore invalid home directory
     }
@@ -252,10 +256,13 @@ bool Is_path_allowed(const std::filesystem::path &path) {
     return false;
   }
 
-  // Check if the resolved path starts with any of the allowlisted canonical directories.
+  // Check if the resolved path starts with any of the allowlisted canonical
+  // directories.
   return std::any_of(
       allowlist.begin(), allowlist.end(), [&](const auto &allowed_path) {
-        return std::mismatch(allowed_path.begin(), allowed_path.end(), resolved_path.begin(), resolved_path.end()).first == allowed_path.end();
+        return std::mismatch(allowed_path.begin(), allowed_path.end(),
+                             resolved_path.begin(), resolved_path.end())
+                   .first == allowed_path.end();
       });
 }
 } // namespace

--- a/examples/driver/qdmi_example_driver.cpp
+++ b/examples/driver/qdmi_example_driver.cpp
@@ -230,18 +230,32 @@ void QDMI_library_load(const std::string &lib_name, const std::string &prefix) {
 }
 
 bool Is_path_allowed(const std::filesystem::path &path) {
-  // Define the allowlist of allowed directories
-  const std::vector<std::filesystem::path> allowlist = {
-      std::filesystem::current_path(),
-      std::filesystem::path(std::getenv("HOME"))};
+  // Construct the allowlist of canonical allowed directories, skipping any nullptr "HOME" values.
+  std::vector<std::filesystem::path> allowlist;
+  allowlist.push_back(std::filesystem::canonical(std::filesystem::current_path()));
+  const char *home_env = std::getenv("HOME");
+  if (home_env != nullptr) {
+    // Only add HOME to the allowlist if it is set and points to a valid directory
+    try {
+      allowlist.push_back(std::filesystem::canonical(std::filesystem::path(home_env)));
+    } catch (const std::filesystem::filesystem_error &) {
+      // Ignore invalid home directory
+    }
+  }
 
-  // Resolve the provided path to its absolute form
-  std::filesystem::path resolved_path = std::filesystem::absolute(path);
+  // Canonicalize the provided path, but only if it exists.
+  std::filesystem::path resolved_path;
+  try {
+    resolved_path = std::filesystem::canonical(path);
+  } catch (const std::filesystem::filesystem_error &) {
+    // If it doesn't exist, deny access
+    return false;
+  }
 
-  // Check if the resolved path starts with any of the allowlisted directories.
+  // Check if the resolved path starts with any of the allowlisted canonical directories.
   return std::any_of(
       allowlist.begin(), allowlist.end(), [&](const auto &allowed_path) {
-        return resolved_path.string().rfind(allowed_path.string(), 0) == 0;
+        return std::mismatch(allowed_path.begin(), allowed_path.end(), resolved_path.begin(), resolved_path.end()).first == allowed_path.end();
       });
 }
 } // namespace

--- a/examples/driver/qdmi_example_driver.cpp
+++ b/examples/driver/qdmi_example_driver.cpp
@@ -232,18 +232,17 @@ void QDMI_library_load(const std::string &lib_name, const std::string &prefix) {
 bool Is_path_allowed(const std::filesystem::path &path) {
   // Construct the allowlist of canonical allowed directories, skipping any
   // nullptr "HOME" values.
-  std::vector<std::filesystem::path> allowlist;
-  allowlist.push_back(
-      std::filesystem::canonical(std::filesystem::current_path()));
-  const char *home_env = std::getenv("HOME");
-  if (home_env != nullptr) {
+  std::vector allowlist{
+      std::filesystem::canonical(std::filesystem::current_path())};
+  if (const char *home_env = std::getenv("HOME"); home_env != nullptr) {
     // Only add HOME to the allowlist if it is set and points to a valid
     // directory
     try {
-      allowlist.push_back(
+      allowlist.emplace_back(
           std::filesystem::canonical(std::filesystem::path(home_env)));
     } catch (const std::filesystem::filesystem_error &) {
-      // Ignore invalid home directory
+      std::cerr << "Ignoring invalid HOME environment variable: " << home_env
+                << '\n';
     }
   }
 
@@ -256,8 +255,7 @@ bool Is_path_allowed(const std::filesystem::path &path) {
     return false;
   }
 
-  // Check if the resolved path starts with any of the allowlisted canonical
-  // directories.
+  // Check if the resolved path starts with any of the allowlisted directories.
   return std::any_of(
       allowlist.begin(), allowlist.end(), [&](const auto &allowed_path) {
         return std::mismatch(allowed_path.begin(), allowed_path.end(),

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -19,17 +19,24 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include "example_fomac.hpp"
 #include "example_tool.hpp"
 #include "qdmi/client.h"
+#include "qdmi_example_driver.h"
 #include "utils/test_impl.hpp"
 
 #include <array>
 #include <complex>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <functional>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <random>
 #include <sstream>
+extern "C" {
+#include <stdlib.h>
+}
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -1134,4 +1141,138 @@ TEST_P(QDMIImplementationTest, QueryPulseSupportLevel) {
       sizeof(QDMI_Device_Pulse_Support_Level), &pulse_support_level, nullptr);
   EXPECT_EQ(ret, QDMI_SUCCESS);
   EXPECT_EQ(pulse_support_level, QDMI_DEVICE_PULSE_SUPPORT_LEVEL_NONE);
+}
+
+// Standalone tests for driver library loading corner cases
+TEST(QDMIDriverLoadingTest, LoadConfigWithNonExistentFile) {
+  // Save the original QDMI_CONF environment variable
+  const char *original_conf = std::getenv("QDMI_CONF");
+  const std::string saved_conf =
+      (original_conf != nullptr) ? original_conf : "";
+
+#ifdef _WIN32
+  _putenv_s("QDMI_CONF", "/nonexistent/path/to/qdmi.conf");
+#else
+  setenv("QDMI_CONF", "/nonexistent/path/to/qdmi.conf", 1);
+#endif
+
+  // Driver initialization should fail because the config file doesn't exist
+  const auto init_result = QDMI_driver_init();
+
+  // Clean up before assertions
+  QDMI_driver_shutdown();
+
+  // Restore the original QDMI_CONF environment variable
+#ifdef _WIN32
+  _putenv_s("QDMI_CONF", saved_conf.c_str());
+#else
+  setenv("QDMI_CONF", saved_conf.c_str(), 1);
+#endif
+
+  // Now perform the assertion after cleanup
+  EXPECT_NE(init_result, QDMI_SUCCESS)
+      << "Driver should fail to initialize with non-existent config file";
+}
+
+TEST(QDMIDriverLoadingTest, LoadLibraryWithNonExistentPath) {
+  // Save the original QDMI_CONF environment variable
+  const char *original_conf = std::getenv("QDMI_CONF");
+  const std::string saved_conf =
+      (original_conf != nullptr) ? original_conf : "";
+
+  // Create a config file pointing to a non-existent library path
+  const std::string config_file_name = "qdmi_nonexistent_library.conf";
+  std::ofstream conf_file(config_file_name);
+  conf_file << "/nonexistent/path/to/library" << Shared_library_file_extension()
+            << " CXX\n";
+  conf_file.close();
+
+#ifdef _WIN32
+  _putenv_s("QDMI_CONF", config_file_name.c_str());
+#else
+  setenv("QDMI_CONF", config_file_name.c_str(), 1);
+#endif
+
+  // Driver initialization should fail because the library path doesn't exist
+  // The Is_path_allowed function should return false when the path cannot be
+  // canonicalized
+  const auto init_result = QDMI_driver_init();
+
+  // Clean up before assertions
+  QDMI_driver_shutdown();
+  std::filesystem::remove(config_file_name);
+
+  // Restore the original QDMI_CONF environment variable
+#ifdef _WIN32
+  if (!saved_conf.empty()) {
+    _putenv_s("QDMI_CONF", saved_conf.c_str());
+  } else {
+    _putenv_s("QDMI_CONF", "");
+  }
+#else
+  if (!saved_conf.empty()) {
+    setenv("QDMI_CONF", saved_conf.c_str(), 1);
+  } else {
+    unsetenv("QDMI_CONF");
+  }
+#endif
+
+  // Now perform the assertion after cleanup
+  EXPECT_NE(init_result, QDMI_SUCCESS)
+      << "Driver should fail to initialize with non-existent library path";
+}
+
+TEST(QDMIDriverLoadingTest, LoadLibraryWithInvalidHomeEnv) {
+  // Save the original HOME environment variable
+  const char *original_home = std::getenv("HOME");
+  const std::string saved_home =
+      (original_home != nullptr) ? original_home : "";
+
+  // Set HOME to a non-existent path
+#ifdef _WIN32
+  _putenv_s("HOME", "/nonexistent/home/directory");
+#else
+  setenv("HOME", "/nonexistent/home/directory", 1);
+#endif
+
+  // Create a valid config file pointing to the example device in the current
+  // directory (test runs from build directory, library is in examples/device/)
+  const std::string config_file_name = "qdmi_invalid_home.conf";
+  std::ofstream conf_file(config_file_name);
+  conf_file << "../examples/device/libcxx_device"
+            << Shared_library_file_extension() << " CXX\n";
+  conf_file.close();
+
+#ifdef _WIN32
+  _putenv_s("QDMI_CONF", config_file_name.c_str());
+#else
+  setenv("QDMI_CONF", config_file_name.c_str(), 1);
+#endif
+
+  // Driver initialization should succeed because the library is in an allowed
+  // path (current directory) even though HOME is invalid. The Is_path_allowed
+  // function should catch the exception when canonicalizing HOME and skip it.
+  const auto init_result = QDMI_driver_init();
+
+  // Clean up and restore the environment BEFORE any assertions
+  QDMI_driver_shutdown();
+  std::filesystem::remove(config_file_name);
+
+  // Restore the original HOME environment variable
+#ifdef _WIN32
+  if (!saved_home.empty()) {
+    _putenv_s("HOME", saved_home.c_str());
+  }
+#else
+  if (!saved_home.empty()) {
+    setenv("HOME", saved_home.c_str(), 1);
+  } else {
+    unsetenv("HOME");
+  }
+#endif
+
+  // Now perform the assertion after cleanup
+  EXPECT_EQ(init_result, QDMI_SUCCESS)
+      << "Driver should initialize successfully even with invalid HOME "
+         "environment variable";
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Munich-Quantum-Software-Stack/QDMI/security/code-scanning/29](https://github.com/Munich-Quantum-Software-Stack/QDMI/security/code-scanning/29)

To robustly prevent path traversal and unwanted file access:
- Modify the `Is_path_allowed` function so that both the provided path and the allowed directories are resolved to their *canonical* (fully resolved, no symlinks, no ".." or ".") forms using `std::filesystem::canonical`. 
- Update the check to compare canonical allowed paths with the canonical test path, ensuring the test path is truly descended from one of the allowed directories.
- Also, check that getenv("HOME") does not return null before adding it to the allowlist.
- Ensure any use of `config_file` in file access is protected by this improved validation.

Make all these edits in the region containing `Is_path_allowed` and its usages; no new headers need to be included since `<filesystem>` is already imported, and error handling can be added as appropriate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
