### PR TITLE
🩹💚📝 Fix the versioned docs workflow

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -16,10 +16,19 @@ jobs:
   build-and-deploy-release-docs:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎️
+      - name: Checkout release tag 🛎️
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           ref: ${{ github.event.release.tag_name || inputs.version }}
+          path: release
+
+      - name: Checkout scripts from main branch 🛎️
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          ref: develop
+          sparse-checkout: |
+            .github/scripts
+          path: scripts
 
       - name: Install Doxygen
         uses: ssciwr/doxygen-install@501e53b879da7648ab392ee226f5b90e42148449 # v1.6.4
@@ -28,9 +37,10 @@ jobs:
 
       - name: Install and Build 🔧
         run: |
+          cd release
           cmake -S . -B build
           cmake --build build --target qdmi_docs
-          mv build/docs/html/ static
+          mv build/docs/html/ ../static
 
       - name: Set version variable
         id: version
@@ -44,8 +54,8 @@ jobs:
 
       - name: Inject version selector
         run: |
-          chmod +x .github/scripts/inject-version-selector.sh
-          .github/scripts/inject-version-selector.sh static
+          chmod +x scripts/.github/scripts/inject-version-selector.sh
+          scripts/.github/scripts/inject-version-selector.sh static
 
       - name: Deploy versioned docs 🚀
         uses: JamesIves/github-pages-deploy-action@4a3abc783e1a24aeb44c16e869ad83caf6b4cc23 # v4.7.4


### PR DESCRIPTION
## Description

This pull request updates the `release-docs.yml` GitHub Actions workflow to improve the build and deployment process for release documentation. The main changes ensure that documentation is built from the correct release tag while always using the latest deployment scripts from the `develop` branch. The build and script paths have also been adjusted to reflect this new structure.

**Workflow improvements:**

* The workflow now checks out the release code into a `release` directory and separately checks out only the `.github/scripts` directory from the `develop` branch into a `scripts` directory, ensuring scripts are always up-to-date regardless of the release tag being built.
* The build process is updated to run from within the `release` directory, and the generated documentation is moved to the correct location outside of this directory.

**Script usage updates:**

* The path to the `inject-version-selector.sh` script is updated to reference the new `scripts` directory, and the script is now executed from this location.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
