### PR TITLE
👨‍💻 Turn off building QDMI documentation by default

### DIFF
--- a/.github/workflows/reusable-cpp-install-tests.yml
+++ b/.github/workflows/reusable-cpp-install-tests.yml
@@ -20,7 +20,7 @@ jobs:
           - name: 🐧
             os: ubuntu-latest
           - name: 🍎
-            os: macos-13
+            os: macos-15-intel
           - name: 🍎
             os: macos-14
       fail-fast: false

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install and Build 🔧
         if: github.event.action != 'closed'
         run: |
-          cmake -S . -B build
+          cmake -S . -B build -DBUILD_QDMI_DOCS=ON
           cmake --build build --target qdmi_docs
           mv build/docs/html/ static
       - name: Inject version selector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ clients compiled against a different minor or major version.
 
 ## [Unreleased]
 
-_No unreleased changes yet._
+### Changed
+
+- 👨‍💻 Turn off building QDMI documentation by default ([#269]) ([\@burgholzer])
 
 ## [1.2.0] - 2025-12-01
 
@@ -87,6 +89,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#269]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/269
 [#252]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/252
 [#250]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/250
 [#234]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/234

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,8 +68,7 @@ option(BUILD_QDMI_TESTS "Also build tests for the QDMI project"
        ${QDMI_MASTER_PROJECT})
 option(BUILD_QDMI_EXAMPLES "Also build examples for the QDMI project"
        ${QDMI_MASTER_PROJECT})
-option(BUILD_QDMI_DOCS "Also build documentation for the QDMI project"
-       ${QDMI_MASTER_PROJECT})
+option(BUILD_QDMI_DOCS "Also build documentation for the QDMI project" OFF)
 option(BUILD_QDMI_TEMPLATES "Also build templates for the QDMI project"
        ${QDMI_MASTER_PROJECT})
 


### PR DESCRIPTION
## Description

This PR turns off the documentation build by default as it seems that people are running into trouble when doxygen is building from source.
This is just a stopgap measure to ensure that people can develop smoothly.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
