### PR TITLE
🐛 Fix target name mismatch for `qdmi_project_warnings` between source and installed version of QDMI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ clients compiled against a different minor or major version.
 
 - 👨‍💻 Turn off building QDMI documentation by default ([#269]) ([\@burgholzer])
 
+### Fixed
+
+- 🐛 Fix target name mismatch for `qdmi_project_warnings` between source and installed version of
+  QDMI ([#270]) ([\@burgholzer])
+
 ## [1.2.0] - 2025-12-01
 
 ### Added
@@ -89,6 +94,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#270]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/270
 [#269]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/269
 [#252]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/252
 [#250]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/250

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,52 +101,55 @@ include(cmake/ExternalDependencies.cmake)
 include(cmake/PrefixHandling.cmake)
 include(GNUInstallDirs)
 
-# add warnings target
-if(NOT TARGET qdmi::project_warnings)
-  # use the warnings specified in CompilerWarnings.cmake
-  add_library(qdmi_project_warnings INTERFACE)
+if(NOT USE_INSTALLED_QDMI)
+  # add warnings target
+  if(NOT TARGET qdmi::qdmi_project_warnings)
+    # use the warnings specified in CompilerWarnings.cmake
+    add_library(qdmi_project_warnings INTERFACE)
 
-  # standard compiler warnings
-  include(${PROJECT_SOURCE_DIR}/cmake/CompilerWarnings.cmake)
-  set_project_warnings(qdmi_project_warnings)
+    # standard compiler warnings
+    include(${PROJECT_SOURCE_DIR}/cmake/CompilerWarnings.cmake)
+    set_project_warnings(qdmi_project_warnings)
 
-  # add alias
-  add_library(qdmi::project_warnings ALIAS qdmi_project_warnings)
-endif()
-
-# add main library code
-if(NOT TARGET qdmi::qdmi)
-  # add main library code
-  add_library(qdmi INTERFACE)
-
-  # collect header files
-  file(GLOB_RECURSE QDMI_HEADERS ${QDMI_INCLUDE_BUILD_DIR}/qdmi/*.h)
-
-  # add headers using file sets
-  target_sources(qdmi PUBLIC FILE_SET HEADERS BASE_DIRS
-                             ${QDMI_INCLUDE_BUILD_DIR} FILES ${QDMI_HEADERS})
-
-  # set required C standard
-  target_compile_features(qdmi INTERFACE c_std_11)
-
-  # always include debug symbols (avoids common problems with LTO)
-  target_compile_options(qdmi INTERFACE -g)
-
-  # enable coverage collection options
-  option(ENABLE_COVERAGE "Enable coverage reporting" FALSE)
-  if(ENABLE_COVERAGE)
-    target_compile_options(qdmi INTERFACE --coverage -fprofile-arcs
-                                          -ftest-coverage -O0)
-    target_link_libraries(qdmi INTERFACE gcov --coverage)
+    # add alias
+    add_library(qdmi::qdmi_project_warnings ALIAS qdmi_project_warnings)
   endif()
 
-  # set the version of the library
-  set_target_properties(
-    qdmi PROPERTIES VERSION ${PROJECT_VERSION}
-                    SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
+  # add main library code
+  if(NOT TARGET qdmi::qdmi)
+    # add main library code
+    add_library(qdmi INTERFACE)
 
-  # add alias
-  add_library(qdmi::qdmi ALIAS qdmi)
+    # collect header files
+    file(GLOB_RECURSE QDMI_HEADERS ${QDMI_INCLUDE_BUILD_DIR}/qdmi/*.h)
+
+    # add headers using file sets
+    target_sources(qdmi PUBLIC FILE_SET HEADERS BASE_DIRS
+                               ${QDMI_INCLUDE_BUILD_DIR} FILES ${QDMI_HEADERS})
+
+    # set required C standard
+    target_compile_features(qdmi INTERFACE c_std_11)
+
+    # always include debug symbols (avoids common problems with LTO)
+    target_compile_options(qdmi INTERFACE -g)
+
+    # enable coverage collection options
+    option(ENABLE_COVERAGE "Enable coverage reporting" FALSE)
+    if(ENABLE_COVERAGE)
+      target_compile_options(qdmi INTERFACE --coverage -fprofile-arcs
+                                            -ftest-coverage -O0)
+      target_link_libraries(qdmi INTERFACE gcov --coverage)
+    endif()
+
+    # set the version of the library
+    set_target_properties(
+      qdmi
+      PROPERTIES VERSION ${PROJECT_VERSION}
+                 SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
+
+    # add alias
+    add_library(qdmi::qdmi ALIAS qdmi)
+  endif()
 endif()
 
 # add documentation

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,7 +6,12 @@ complete list of changes, including minor and patch releases, please refer to th
 
 ## [Unreleased]
 
-_No unreleased changes yet._
+### Fix for using Installed Version of QDMI
+
+In order to avoid a mismatch in the target name for the `qdmi_project_warnings` target between the
+source and installed versions of QDMI, the target alias has been adjusted. If your project relies on
+`qdmi::project_warnings`, you need to change it to `qdmi::qdmi_project_warnings`. More rationale is
+available in [the PR description](https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/270).
 
 ## [1.2.0] - 2025-12-01
 

--- a/cmake/PrefixHandling.cmake
+++ b/cmake/PrefixHandling.cmake
@@ -72,7 +72,7 @@ function(generate_device_defs_executable prefix)
                  ${CMAKE_CURRENT_BINARY_DIR}/${QDMI_prefix}_test_defs.cpp)
   target_link_libraries(
     qdmi_test_${QDMI_prefix}_device_defs
-    PRIVATE qdmi::qdmi qdmi::${QDMI_prefix}_device qdmi::project_warnings)
+    PRIVATE qdmi::qdmi qdmi::${QDMI_prefix}_device qdmi::qdmi_project_warnings)
   target_compile_features(qdmi_test_${QDMI_prefix}_device_defs
                           PRIVATE cxx_std_17)
 endfunction()

--- a/examples/device/CMakeLists.txt
+++ b/examples/device/CMakeLists.txt
@@ -23,7 +23,7 @@ enable_language(CXX)
 # change. Hence, in the test you have to adopt the name of the shared library
 # accordingly.
 add_library(cxx_device SHARED device.cpp)
-target_link_libraries(cxx_device PRIVATE qdmi::qdmi qdmi::project_warnings)
+target_link_libraries(cxx_device PRIVATE qdmi::qdmi qdmi::qdmi_project_warnings)
 generate_prefixed_qdmi_headers("CXX")
 target_include_directories(cxx_device
                            PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)

--- a/examples/driver/CMakeLists.txt
+++ b/examples/driver/CMakeLists.txt
@@ -21,7 +21,7 @@ enable_language(CXX)
 
 add_library(qdmi_example_driver qdmi_example_driver.cpp qdmi_example_driver.h)
 target_link_libraries(qdmi_example_driver PRIVATE qdmi::qdmi
-                                                  qdmi::project_warnings)
+                                                  qdmi::qdmi_project_warnings)
 target_include_directories(qdmi_example_driver
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(qdmi_example_driver PRIVATE cxx_std_17)

--- a/examples/fomac/CMakeLists.txt
+++ b/examples/fomac/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_library(qdmi_example_fomac example_fomac.cpp example_fomac.hpp)
 target_link_libraries(qdmi_example_fomac PRIVATE qdmi::qdmi
-                                                 qdmi::project_warnings)
+                                                 qdmi::qdmi_project_warnings)
 target_include_directories(qdmi_example_fomac
                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(qdmi_example_fomac PRIVATE cxx_std_17)

--- a/templates/device/src/CMakeLists.txt
+++ b/templates/device/src/CMakeLists.txt
@@ -16,7 +16,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # ------------------------------------------------------------------------------
 add_library(my_device SHARED my_device.cpp)
-target_link_libraries(my_device PRIVATE qdmi::qdmi qdmi::project_warnings)
+target_link_libraries(my_device PRIVATE qdmi::qdmi qdmi::qdmi_project_warnings)
 generate_prefixed_qdmi_headers(${QDMI_PREFIX})
 target_include_directories(my_device PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
 if(NOT CXX_DEVICE)

--- a/templates/device/test/CMakeLists.txt
+++ b/templates/device/test/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(my_device_test test_my_device.cpp)
 
 # link the Google test infrastructure to the test executable.
 target_link_libraries(my_device_test PRIVATE gtest_main qdmi::qdmi my_device
-                                             qdmi::project_warnings)
+                                             qdmi::qdmi_project_warnings)
 
 # set c++ standard
 target_compile_features(my_device_test PRIVATE cxx_std_17)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(
           qdmi::example_tool
           qdmi::example_fomac
           qdmi::example_driver
-          qdmi::project_warnings
+          qdmi::qdmi_project_warnings
           GTest::gtest_main
           GTest::gmock)
 

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -3,7 +3,7 @@
 add_library(qdmi_test_impl SHARED test_impl.cpp test_impl.hpp)
 target_link_libraries(
   qdmi_test_impl PRIVATE GTest::gtest GTest::gmock qdmi::qdmi
-                         qdmi::example_driver qdmi::project_warnings)
+                         qdmi::example_driver qdmi::qdmi_project_warnings)
 target_include_directories(qdmi_test_impl PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_features(qdmi_test_impl PRIVATE cxx_std_17)
 add_library(qdmi::test_impl ALIAS qdmi_test_impl)


### PR DESCRIPTION
## Description

This fixes an oversight in the QDMI installation instructions that would lead to a target mismatch between a source version of QDMI and an installed version.
The source version would refer to `qdmi::project_warnings`, while the installed version provides `qdmi::qdmi_project_warnings`.
The main reason for that is that the installation instructions prefix all regular target names with `qdmi::` (which is intended).
The reason this hasn't been caught in the `USE_INSTALLED_QDMI` CI tests is that the main `CMakeLists.txt` checked whether it could find the `qdmi::project_warnings` target and define it anew if it could not.
While this works locally in the QDMI repository, this does not work in an external project that tries to use an installed version of QDMI (that version won't run through the original `CMakeLists.txt`, but only through the package config file `qdmi-config.cmake`).

The fix here is to adjust the respective target alias and to change all occurrences of `qdmi::project_warnings` in the codebase to `qdmi::qdmi_project_warnings`.

Note that we cannot simply call the target `project_warnings` as this has a high risk of conflicting with other CMake-based projects such as the MQT. Thus, the `qdmi` duplication in the prefixed target name is kind of necessary.

Any consuming project will have to update their link target if they previously linked against `qdmi::project_warnings`.
I will backport this to a `v1.2.x` branch so that we can release a patch version.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
