### PR TITLE
🚸 Provide compile definitions for inferring device and QDMI versions automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ clients compiled against a different minor or major version.
 
 ## [Unreleased]
 
+### Added
+
+- 🚸 Provide compile definitions for inferring device and QDMI versions automatically ([#272])
+  ([\@burgholzer])
+
 ### Changed
 
 - 👨‍💻 Turn off building QDMI documentation by default ([#269]) ([\@burgholzer])
@@ -94,6 +99,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#272]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/272
 [#270]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/270
 [#269]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/269
 [#252]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/252

--- a/examples/device/CMakeLists.txt
+++ b/examples/device/CMakeLists.txt
@@ -30,5 +30,5 @@ target_include_directories(cxx_device
 target_compile_features(cxx_device PRIVATE cxx_std_17)
 add_library(qdmi::cxx_device ALIAS cxx_device)
 target_compile_definitions(
-  cxx_device PRIVATE QDMI_VERSION="${QDMI_VERSION}"
+  cxx_device PRIVATE QDMI_VERSION="${qdmi_VERSION}"
                      DEVICE_VERSION="${PROJECT_VERSION}")

--- a/examples/device/CMakeLists.txt
+++ b/examples/device/CMakeLists.txt
@@ -29,3 +29,6 @@ target_include_directories(cxx_device
                            PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
 target_compile_features(cxx_device PRIVATE cxx_std_17)
 add_library(qdmi::cxx_device ALIAS cxx_device)
+target_compile_definitions(
+  cxx_device PRIVATE QDMI_VERSION="${QDMI_VERSION}"
+                     DEVICE_VERSION="${PROJECT_VERSION}")

--- a/examples/device/CMakeLists.txt
+++ b/examples/device/CMakeLists.txt
@@ -29,6 +29,7 @@ target_include_directories(cxx_device
                            PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
 target_compile_features(cxx_device PRIVATE cxx_std_17)
 add_library(qdmi::cxx_device ALIAS cxx_device)
+get_target_property(qdmi_library_VERSION qdmi::qdmi VERSION)
 target_compile_definitions(
-  cxx_device PRIVATE QDMI_VERSION="${qdmi_VERSION}"
+  cxx_device PRIVATE QDMI_VERSION="${qdmi_library_VERSION}"
                      DEVICE_VERSION="${PROJECT_VERSION}")

--- a/examples/device/device.cpp
+++ b/examples/device/device.cpp
@@ -757,9 +757,11 @@ int CXX_QDMI_device_session_query_device_property(
   }
   ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_NAME, "C++ Device with 5 qubits",
                       prop, size, value, size_ret)
-  ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_VERSION, "0.1.0", prop, size, value,
-                      size_ret)
-  ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_LIBRARYVERSION, "1.3.0-dev", prop,
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_VERSION, DEVICE_VERSION, prop, size,
+                      value, size_ret)
+  // NOLINTNEXTLINE(misc-include-cleaner)
+  ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_LIBRARYVERSION, QDMI_VERSION, prop,
                       size, value, size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_STATUS, QDMI_Device_Status,
                             CXX_QDMI_get_device_status(), prop, size, value,

--- a/templates/device/src/CMakeLists.txt
+++ b/templates/device/src/CMakeLists.txt
@@ -24,6 +24,7 @@ if(NOT CXX_DEVICE)
   target_compile_features(my_device PRIVATE cxx_std_17)
 endif()
 add_library(qdmi::my_device ALIAS my_device)
+get_target_property(qdmi_library_VERSION qdmi::qdmi VERSION)
 target_compile_definitions(
-  my_device PRIVATE QDMI_VERSION="${qdmi_VERSION}"
+  my_device PRIVATE QDMI_VERSION="${qdmi_library_VERSION}"
                     DEVICE_VERSION="${PROJECT_VERSION}")

--- a/templates/device/src/CMakeLists.txt
+++ b/templates/device/src/CMakeLists.txt
@@ -25,5 +25,5 @@ if(NOT CXX_DEVICE)
 endif()
 add_library(qdmi::my_device ALIAS my_device)
 target_compile_definitions(
-  my_device PRIVATE QDMI_VERSION="${QDMI_VERSION}"
+  my_device PRIVATE QDMI_VERSION="${qdmi_VERSION}"
                     DEVICE_VERSION="${PROJECT_VERSION}")

--- a/templates/device/src/CMakeLists.txt
+++ b/templates/device/src/CMakeLists.txt
@@ -24,3 +24,6 @@ if(NOT CXX_DEVICE)
   target_compile_features(my_device PRIVATE cxx_std_17)
 endif()
 add_library(qdmi::my_device ALIAS my_device)
+target_compile_definitions(
+  my_device PRIVATE QDMI_VERSION="${QDMI_VERSION}"
+                    DEVICE_VERSION="${PROJECT_VERSION}")


### PR DESCRIPTION
## Description

This PR adds some compile definitions to the example device as well as the template that allow to automatically infer the version in the device implementation from the versions set through CMake.
One less place to update the version of QDMI for us (and everyone else).

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
