### PR TITLE
🚸 Improve prefix handling by making the device target name flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ clients compiled against a different minor or major version.
 
 ### Changed
 
+- 🚸 Improve prefix handling by making the device target name flexible ([#274]) ([\@burgholzer])
 - 👨‍💻 Turn off building QDMI documentation by default ([#269]) ([\@burgholzer])
 
 ### Fixed
@@ -100,6 +101,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#274]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/274
 [#273]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/273
 [#272]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/272
 [#270]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/270

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,6 +13,23 @@ source and installed versions of QDMI, the target alias has been adjusted. If yo
 `qdmi::project_warnings`, you need to change it to `qdmi::qdmi_project_warnings`. More rationale is
 available in [the PR description](https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/270).
 
+### Changes to Prefix Handling
+
+The CMake functionality for handling the prefixing of QDMI devices was refactored to improve the
+usability and flexibility. Particularly, the `generate_prefixed_qdmi_headers` and
+`generate_device_defs_executable` CMake functions have been changed to
+
+- Take the prefix as a keyword argument instead of a positional argument
+- Allow the optional specification of the QDMI device target to link in the
+  `generate_device_defs_executable` function via a `TARGET` keyword argument.
+
+Call to these functions should be updated accordingly. Example usage:
+
+```cmake
+generate_prefixed_qdmi_headers(PREFIX "my_prefix")
+generate_device_defs_executable(PREFIX "my_prefix" TARGET my_device)
+```
+
 ## [1.2.0] - 2025-12-01
 
 Version 1.2.0 introduces several breaking changes, primarily related to type system improvements,

--- a/cmake/PrefixHandling.cmake
+++ b/cmake/PrefixHandling.cmake
@@ -17,9 +17,23 @@
 # ------------------------------------------------------------------------------
 
 # A function for generating prefixed QDMI headers for a user-defined prefix.
-function(generate_prefixed_qdmi_headers prefix)
+#
+# Arguments: PREFIX - The prefix for the device (required)
+#
+# Usage: generate_prefixed_qdmi_headers(PREFIX "MY")
+function(generate_prefixed_qdmi_headers)
+  # Parse arguments
+  set(oneValueArgs PREFIX)
+  cmake_parse_arguments(ARG "" "${oneValueArgs}" "" ${ARGN})
+
+  # Validate required argument
+  if(NOT ARG_PREFIX)
+    message(
+      FATAL_ERROR "generate_prefixed_qdmi_headers: PREFIX argument is required")
+  endif()
+
   # Get the lowercase version of the prefix.
-  string(TOLOWER ${prefix} QDMI_prefix)
+  string(TOLOWER ${ARG_PREFIX} QDMI_prefix)
 
   # Determine the correct include directory
   set(QDMI_INCLUDE_DIR "${QDMI_INCLUDE_BUILD_DIR}")
@@ -60,7 +74,7 @@ function(generate_prefixed_qdmi_headers prefix)
       string(
         REGEX
         REPLACE "([^a-zA-Z0-9_])${replacement}([^a-zA-Z0-9_])"
-                "\\1${prefix}_${replacement}\\2" header_content
+                "\\1${ARG_PREFIX}_${replacement}\\2" header_content
                 "${header_content}")
     endforeach()
     # Write the prefixed header.
@@ -74,10 +88,35 @@ endfunction()
 # implemented by a device.
 #
 # NOTE: The executables are not meant to be executed, only built.
-function(generate_device_defs_executable prefix)
-  set(QDMI_PREFIX ${prefix})
+#
+# Arguments: PREFIX - The prefix for the device (required) TARGET - The device
+# target to link against (optional, defaults to qdmi::${prefix}_device)
+#
+# Usage: generate_device_defs_executable(PREFIX "MY")  # Links against
+# qdmi::my_device generate_device_defs_executable(PREFIX "MY" TARGET
+# my_custom_device)  # Links against my_custom_device
+function(generate_device_defs_executable)
+  # Parse arguments
+  set(oneValueArgs PREFIX TARGET)
+  cmake_parse_arguments(ARG "" "${oneValueArgs}" "" ${ARGN})
+
+  # Validate required argument
+  if(NOT ARG_PREFIX)
+    message(
+      FATAL_ERROR "generate_device_defs_executable: PREFIX argument is required"
+    )
+  endif()
+
+  set(QDMI_PREFIX ${ARG_PREFIX})
   # Get the lowercase version of the prefix.
-  string(TOLOWER ${prefix} QDMI_prefix)
+  string(TOLOWER ${QDMI_PREFIX} QDMI_prefix)
+
+  # Use provided target or default to qdmi::${QDMI_prefix}_device
+  if(ARG_TARGET)
+    set(DEVICE_TARGET ${ARG_TARGET})
+  else()
+    set(DEVICE_TARGET qdmi::${QDMI_prefix}_device)
+  endif()
 
   # Determine the correct CMake directory for prefix_defs.txt
   set(QDMI_PREFIX_DIR "${QDMI_CMAKE_DIR}")
@@ -92,8 +131,8 @@ function(generate_device_defs_executable prefix)
   add_executable(qdmi_test_${QDMI_prefix}_device_defs
                  ${CMAKE_CURRENT_BINARY_DIR}/${QDMI_prefix}_test_defs.cpp)
   target_link_libraries(
-    qdmi_test_${QDMI_prefix}_device_defs
-    PRIVATE qdmi::qdmi qdmi::${QDMI_prefix}_device qdmi::qdmi_project_warnings)
+    qdmi_test_${QDMI_prefix}_device_defs PRIVATE qdmi::qdmi ${DEVICE_TARGET}
+                                                 qdmi::qdmi_project_warnings)
   target_compile_features(qdmi_test_${QDMI_prefix}_device_defs
                           PRIVATE cxx_std_17)
 endfunction()

--- a/examples/device/CMakeLists.txt
+++ b/examples/device/CMakeLists.txt
@@ -24,11 +24,10 @@ enable_language(CXX)
 # accordingly.
 add_library(cxx_device SHARED device.cpp)
 target_link_libraries(cxx_device PRIVATE qdmi::qdmi qdmi::qdmi_project_warnings)
-generate_prefixed_qdmi_headers("CXX")
+generate_prefixed_qdmi_headers(PREFIX "CXX")
 target_include_directories(cxx_device
                            PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
 target_compile_features(cxx_device PRIVATE cxx_std_17)
-add_library(qdmi::cxx_device ALIAS cxx_device)
 get_target_property(qdmi_library_VERSION qdmi::qdmi VERSION)
 target_compile_definitions(
   cxx_device PRIVATE QDMI_VERSION="${qdmi_library_VERSION}"

--- a/templates/device/src/CMakeLists.txt
+++ b/templates/device/src/CMakeLists.txt
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------------
 add_library(my_device SHARED my_device.cpp)
 target_link_libraries(my_device PRIVATE qdmi::qdmi qdmi::qdmi_project_warnings)
-generate_prefixed_qdmi_headers(${QDMI_PREFIX})
+generate_prefixed_qdmi_headers(PREFIX ${QDMI_PREFIX})
 target_include_directories(my_device PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/include)
 if(NOT CXX_DEVICE)
   # set c++ standard

--- a/templates/device/test/CMakeLists.txt
+++ b/templates/device/test/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 # Non-Functional Tests
 # ------------------------------------------------------------------------------
 
-generate_device_defs_executable(${QDMI_PREFIX})
+generate_device_defs_executable(PREFIX ${QDMI_PREFIX} TARGET my_device)
 
 # ------------------------------------------------------------------------------
 # Functional Tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,7 +28,7 @@ add_subdirectory(utils)
 # ------------------------------------------------------------------------------
 # Non-Functional Tests
 # ------------------------------------------------------------------------------
-generate_device_defs_executable("CXX")
+generate_device_defs_executable(PREFIX "CXX" TARGET cxx_device)
 
 # ------------------------------------------------------------------------------
 # Functional Tests
@@ -60,7 +60,7 @@ gtest_discover_tests(
 
 # ensure cxx_device are built whenever qdmi_test is built. Those targets build
 # the dynamic libraries that are loaded in the tests.
-add_dependencies(qdmi_test qdmi::cxx_device)
+add_dependencies(qdmi_test cxx_device)
 # ensure qdmi_test_cxx_device_defs are built whenever qdmi_test is built. Those
 # targets ensure that the respective devices implement all interface functions.
 add_dependencies(qdmi_test qdmi_test_cxx_device_defs)


### PR DESCRIPTION
## Description

The CMake functionality for handling the prefixing of QDMI devices was refactored to improve the
usability and flexibility. Particularly, the `generate_prefixed_qdmi_headers` and
`generate_device_defs_executable` CMake functions have been changed to

- Take the prefix as a keyword argument instead of a positional argument
- Allow the optional specification of the QDMI device target to link in the
  `generate_device_defs_executable` function via a `TARGET` keyword argument.

Call to these functions should be updated accordingly. Example usage:

```cmake
generate_prefixed_qdmi_headers(PREFIX "my_prefix")
generate_device_defs_executable(PREFIX "my_prefix" TARGET my_device)
```

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
