### PR TITLE
🚨 Avoid specifying `-g` on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,9 @@ if(NOT USE_INSTALLED_QDMI)
     target_compile_features(qdmi INTERFACE c_std_11)
 
     # always include debug symbols (avoids common problems with LTO)
-    target_compile_options(qdmi INTERFACE -g)
+    if(NOT MSVC)
+      target_compile_options(qdmi INTERFACE -g)
+    endif()
 
     # enable coverage collection options
     option(ENABLE_COVERAGE "Enable coverage reporting" FALSE)


### PR DESCRIPTION
## Description

This avoids a compiler warning on Windows about an unknown option `-g`.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
