### PR TITLE
🍢 Use kebab-case for default template output directory

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -28,7 +28,7 @@ cmake -DQDMI_GENERATE_TEMPLATE=ON \
 cmake --build build --target qdmi-template
 ```
 
-If the option `TEMPLATE_PATH` is not given it will be placed in `PREFIX_qdmi_device` relative to the
+If the option `TEMPLATE_PATH` is not given it will be placed in `PREFIX-qdmi-device` relative to the
 parent directory where QDMI was cloned in.
 
 If you want to regenerate into an existing directory, use:

--- a/templates/CMakeLists.txt
+++ b/templates/CMakeLists.txt
@@ -27,7 +27,7 @@ if(QDMI_GENERATE_TEMPLATE)
   string(TOLOWER "${TEMPLATE_PREFIX}" TEMPLATE_prefix)
 
   set(TEMPLATE_PATH
-      "${CMAKE_SOURCE_DIR}/../${TEMPLATE_prefix}_qdmi_device"
+      "${CMAKE_SOURCE_DIR}/../${TEMPLATE_prefix}-qdmi-device"
       CACHE PATH "Path where the instantiated template should be generated")
   file(REAL_PATH "${TEMPLATE_PATH}" TEMPLATE_PATH)
 


### PR DESCRIPTION
## Description

The default `TEMPLATE_PATH` used snake_case (`prefix_qdmi_device`) but should use kebab-case (`prefix-qdmi-device`) to match the project naming convention and align with external device repositories (e.g., `amazon-braket-qdmi-device`).

When generating a device template without specifying a `TEMPLATE_PATH`, the output directory now correctly uses kebab-case, consistent with the CMake project name (`my-qdmi-device`) defined inside the template itself.

**Changes:**
- `templates/CMakeLists.txt`: Updated default `TEMPLATE_PATH` from `${TEMPLATE_prefix}_qdmi_device` to `${TEMPLATE_prefix}-qdmi-device`
- `docs/templates.md`: Updated documentation to reflect the new default path

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
