### PR TITLE
🐛 Install CMake config files as part of the `qdmi_Development` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ clients compiled against a different minor or major version.
 - 📝 Improve contributing guidelines and documentation ([#354]) ([\@burgholzer])
 - 📝 Improve documentation of the QDMI device template ([#354]) ([\@burgholzer])
 
+### Fixed
+
+- 🐛 Install CMake config files as part of the `qdmi_Development` component ([#371]) ([\@burgholzer])
+
 ## [1.2.1] - 2025-12-22
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#121)._
@@ -125,6 +129,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#371]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/371
 [#355]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/355
 [#354]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/354
 [#334]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/334

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,9 +194,11 @@ if(QDMI_INSTALL)
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMinorVersion)
 
-  install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-                "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-          DESTINATION ${QDMI_CONFIG_INSTALL_DIR})
+  install(
+    FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+          "${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+    DESTINATION ${QDMI_CONFIG_INSTALL_DIR}
+    COMPONENT ${PROJECT_NAME}_Development)
 
   set(QDMI_INSTALL_TARGETS ${QDMI_INSTALL_TARGETS} qdmi qdmi_project_warnings)
   if(ENABLE_COVERAGE)


### PR DESCRIPTION
## Description

This PR fixes an oversight in the installation configuration that would prevent the CMake config files from being installed as part of the `qdmi_Development` component.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
