### PR TITLE
🐛 Fix linking of multiple static devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ clients compiled against a different minor or major version.
 
 ### Changed
 
-- 🚸 Export _all_ device headers (incl. `constants.h`) as part of device implementations such that they do not need to link against the header-only QDMI library anymore ([#325]) ([\@ystade], [\@burgholzer])
+- 🚸 Export _all_ device headers (incl. `constants.h`) as part of device implementations such that they do not need to link against the header-only QDMI library anymore ([#325], [#373]) ([\@ystade], [\@burgholzer])
 - 🚸 Increase robustness of the QDMI device template (complete install instructions, uv caching, code cleanup) ([#333]) ([\@burgholzer])
 - 🚸 Add a symbol-export header for compiling devices with hidden symbol visibility ([#334]) ([\@burgholzer])
 - 📝 Improve contributing guidelines and documentation ([#354]) ([\@burgholzer])
@@ -129,6 +129,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#373]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/373
 [#371]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/371
 [#355]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/355
 [#354]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/354

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -22,7 +22,8 @@
  * and the @ref device_interface.
  */
 
-#pragma once
+#ifndef QDMI_CONSTANTS_H
+#define QDMI_CONSTANTS_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -1163,3 +1164,5 @@ typedef enum QDMI_DEVICE_PULSE_SUPPORT_LEVEL_T QDMI_Device_Pulse_Support_Level;
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif // QDMI_CONSTANTS_H


### PR DESCRIPTION
## Description

This PR fixes an oversight in #325 that made it impossible to statically link two device implementations together as they would create duplicate symbols due to the `constants.h` header being imported from each of the device implementations.

The fix is to use a traditional header include guard over `#pragma once` so that the respective header is only ever included once.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
