### PR TITLE
🚸 Fix visibility property for inlines in CMake configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ clients compiled against a different minor or major version.
 
 - 🚸 Export _all_ device headers (incl. `constants.h`) as part of device implementations such that they do not need to link against the header-only QDMI library anymore ([#325], [#373]) ([\@ystade], [\@burgholzer])
 - 🚸 Increase robustness of the QDMI device template (complete install instructions, uv caching, code cleanup) ([#333]) ([\@burgholzer])
-- 🚸 Add a symbol-export header for compiling devices with hidden symbol visibility ([#334], [#375]) ([\@burgholzer])
+- 🚸 Add a symbol-export header for compiling devices with hidden symbol visibility ([#334], [#375], [#377]) ([\@burgholzer])
 - 📝 Improve contributing guidelines and documentation ([#354]) ([\@burgholzer])
 - 📝 Improve documentation of the QDMI device template ([#354]) ([\@burgholzer])
 
@@ -129,6 +129,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#377]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/377
 [#375]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/375
 [#373]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/373
 [#371]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/371

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -42,7 +42,7 @@ target_compile_definitions(${QDMI_TARGET_NAME} PRIVATE MY_QDMI_device_EXPORTS)
 set_target_properties(${QDMI_TARGET_NAME} PROPERTIES
                       C_VISIBILITY_PRESET hidden
                       CXX_VISIBILITY_PRESET hidden
-                      CXX_VISIBILITY_INLINES_HIDDEN 1)
+                      VISIBILITY_INLINES_HIDDEN 1)
 ```
 
 where `MY` is, again, the device prefix.

--- a/examples/device/CMakeLists.txt
+++ b/examples/device/CMakeLists.txt
@@ -39,4 +39,4 @@ set_target_properties(
   cxx_device
   PROPERTIES C_VISIBILITY_PRESET hidden
              CXX_VISIBILITY_PRESET hidden
-             CXX_VISIBILITY_INLINES_HIDDEN 1)
+             VISIBILITY_INLINES_HIDDEN 1)

--- a/templates/device/src/CMakeLists.txt
+++ b/templates/device/src/CMakeLists.txt
@@ -40,7 +40,7 @@ set_target_properties(
   ${QDMI_TARGET_NAME}
   PROPERTIES C_VISIBILITY_PRESET hidden
              CXX_VISIBILITY_PRESET hidden
-             CXX_VISIBILITY_INLINES_HIDDEN 1)
+             VISIBILITY_INLINES_HIDDEN 1)
 target_sources(${QDMI_TARGET_NAME} PRIVATE ${SRC_FILES})
 
 target_sources(


### PR DESCRIPTION
## Description

Fixes an oversight in previous PRs. The property is actually called `VISIBILITY_INLINES_HIDDEN` (https://cmake.org/cmake/help/latest/prop_tgt/VISIBILITY_INLINES_HIDDEN.html) and not `CXX_VISIBILITY_INLINES_HIDDEN`.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
