### PR TITLE
:memo: Clarify symbol visibility in `UPGRADING.md`

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -31,11 +31,15 @@ where `my` is the prefix of your device implementation.
 ### New header for managing exported symbols of device implementations
 
 Device implementations may now be compiled with hidden symbol visibility, which is a common best practice for C++ libraries to reduce symbol clashes and improve load times.
-To ensure that all necessary symbols are exported, a new header file `my_qdmi/export.h` (where `my` is the device prefix) is provided as part of the device template.
-This header defines a macro for marking symbols for export, and you should use this macro to annotate all public symbols in your device implementation.
-Generally, we do this for you, by marking all QDMI interface functions with `MY_QDMI_EXPORT`.
+In practice, this means that only symbols explicitly marked for export are accessible from outside the device library.
 
-The only thing that device implementations need to do is to provide a compile-definition for `MY_QDMI_device_EXPORTS` and the settings for compiling with hidden symbol visibility:
+The header `my_qdmi/export.h` (where `my` is your device prefix) provides the export macro `MY_QDMI_EXPORT`.
+Use this header to control which symbols are part of your public API.
+
+All QDMI interface functions are already marked for export in `my_qdmi/device.h`.
+You only need to add `MY_QDMI_EXPORT` manually for additional custom public functions.
+
+To enable this behavior, add the following CMake code to your device target's configuration:
 
 ```cmake
 target_compile_definitions(${QDMI_TARGET_NAME} PRIVATE MY_QDMI_device_EXPORTS)
@@ -45,7 +49,7 @@ set_target_properties(${QDMI_TARGET_NAME} PROPERTIES
                       VISIBILITY_INLINES_HIDDEN 1)
 ```
 
-where `MY` is, again, the device prefix.
+where `MY` is your device prefix.
 
 ### Updated QDMI device template
 


### PR DESCRIPTION
## Description

When implementing the symbol visibility, I had a hard time wrapping my head around what exactly was expected of device developers. This PR attempts to reformulate the respective paragraph in the `UPGRADING.md` guide. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
