### PR TITLE
📌 Prepare v1.3.0 Release

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -15,7 +15,7 @@ jobs:
         if: github.event.action != 'closed'
         uses: ssciwr/doxygen-install@329d88f5a303066a5bd006db7516b1925b86350e # v2.0.1
         with:
-          version: "1.15.0"
+          version: "1.16.1"
       - name: Install and Build 🔧
         if: github.event.action != 'closed'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ clients compiled against a different minor or major version.
 
 ## [Unreleased]
 
+### Changed
+
+- 🚸 Export _all_ device headers (incl. `constants.h`) as part of device implementations such that they do not need to link against the header-only QDMI library anymore ([#325], [#373]) ([\@ystade], [\@burgholzer])
+- 🚸 Add a symbol-export header for compiling devices with hidden symbol visibility ([#334], [#375], [#377]) ([\@burgholzer])
+
+## [1.2.2] - 2026-04-20
+
+_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#122)._
+
 ### Added
 
 - 👷 Add mergify configuration for easier backports and maintenance of release branches ([#355]) ([\@burgholzer])
@@ -18,9 +27,7 @@ clients compiled against a different minor or major version.
 
 ### Changed
 
-- 🚸 Export _all_ device headers (incl. `constants.h`) as part of device implementations such that they do not need to link against the header-only QDMI library anymore ([#325], [#373]) ([\@ystade], [\@burgholzer])
 - 🚸 Increase robustness of the QDMI device template (complete install instructions, uv caching, code cleanup) ([#333]) ([\@burgholzer])
-- 🚸 Add a symbol-export header for compiling devices with hidden symbol visibility ([#334], [#375], [#377]) ([\@burgholzer])
 - 📝 Improve contributing guidelines and documentation ([#354]) ([\@burgholzer])
 - 📝 Improve documentation of the QDMI device template ([#354]) ([\@burgholzer])
 
@@ -122,7 +129,8 @@ changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.2.1...HEAD
+[unreleased]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.2.2...HEAD
+[1.2.2]: https://github.com/Munich-Quantum-Software-Stack/QDMI/releases/tag/v1.2.2
 [1.2.1]: https://github.com/Munich-Quantum-Software-Stack/QDMI/releases/tag/v1.2.1
 [1.2.0]: https://github.com/Munich-Quantum-Software-Stack/QDMI/releases/tag/v1.2.0
 [1.1.0]: https://github.com/Munich-Quantum-Software-Stack/QDMI/releases/tag/v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ clients compiled against a different minor or major version.
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-21
+
+_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#130)._
+
 ### Changed
 
 - 🚸 Export _all_ device headers (incl. `constants.h`) as part of device implementations such that they do not need to link against the header-only QDMI library anymore ([#325], [#373]) ([\@ystade], [\@burgholzer])
-- 🚸 Add a symbol-export header for compiling devices with hidden symbol visibility ([#334], [#375], [#377]) ([\@burgholzer])
+- 🚸 Add a symbol-export header (`export.h`) for compiling devices with hidden symbol visibility ([#334], [#375], [#377]) ([\@burgholzer])
 
 ## [1.2.2] - 2026-04-20
 
@@ -129,7 +133,8 @@ changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.2.2...HEAD
+[unreleased]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/Munich-Quantum-Software-Stack/QDMI/releases/tag/v1.3.0
 [1.2.2]: https://github.com/Munich-Quantum-Software-Stack/QDMI/releases/tag/v1.2.2
 [1.2.1]: https://github.com/Munich-Quantum-Software-Stack/QDMI/releases/tag/v1.2.1
 [1.2.0]: https://github.com/Munich-Quantum-Software-Stack/QDMI/releases/tag/v1.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,6 +15,7 @@ preferred-citation:
     conference: "IEEE International Conference on Quantum Computing and Engineering (QCE)"
     year: 2024
     month: 9
+    doi: "10.1109/QCE60285.2024.10411"
     authors:
       - given-names: Robert
         family-names: Wille

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ project(
   VERSION 1.3.0
   DESCRIPTION "QDMI –– Quantum Device Management Interface")
 
-set(PROJECT_VERSION_PRERELEASE "-dev")
+set(PROJECT_VERSION_PRERELEASE "")
 set(PROJECT_VERSION_FULL "${PROJECT_VERSION}${PROJECT_VERSION_PRERELEASE}")
 
 # enable organization of targets into folders

--- a/README.md
+++ b/README.md
@@ -107,11 +107,12 @@ If you use QDMI in your research, please cite the following paper:
 
 ```bibtex
 @inproceedings{qdmi,
-    title = {{QDMI -- Quantum Device Management Interface: A Standardized Interface for Quantum Computing Platforms}},
+    title = {{QDMI -- Quantum Device Management Interface: Hardware-Software Interface for the Munich Quantum Software Stack}},
     shorttitle = {{QDMI -- Quantum Device Management Interface}},
     booktitle = {IEEE International Conference on Quantum Computing and Engineering (QCE)},
     author = {Wille, Robert and Schmid, Ludwig and Stade, Yannick and Echavarria, Jorge and Schulz, Martin and Schulz, Laura and Burgholzer, Lukas},
     date = {2024},
+    doi = {10.1109/QCE60285.2024.10411},
 }
 ```
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -51,6 +51,8 @@ set_target_properties(${QDMI_TARGET_NAME} PROPERTIES
 
 where `MY` is your device prefix.
 
+## [1.2.2] - 2026-04-20
+
 ### Updated QDMI device template
 
 The QDMI device template has been updated to be compatible with the latest version of the QDMI specification and to include several improvements.
@@ -371,6 +373,7 @@ For quick reference, here are all breaking changes in v1.2.0:
 5. **`QDMI_JOB_STATUS` enum**: Reordered to reflect job lifecycle
 6. **CMake**: Minimum version raised to 3.24
 
-[unreleased]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.2.1...HEAD
+[unreleased]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.2.2...HEAD
+[1.2.2]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.1.0...v1.2.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,8 @@ complete list of changes, including minor and patch releases, please refer to th
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-21
+
 ### No need to link devices against the QDMI header-only library
 
 As of this release, the QDMI header-only library is no longer required to be linked into QDMI device implementations.
@@ -34,7 +36,7 @@ Device implementations may now be compiled with hidden symbol visibility, which 
 In practice, this means that only symbols explicitly marked for export are accessible from outside the device library.
 
 The header `my_qdmi/export.h` (where `my` is your device prefix) provides the export macro `MY_QDMI_EXPORT`.
-Use this header to control which symbols are part of your public API.
+Use this header to control, which symbols are part of your public API.
 
 All QDMI interface functions are already marked for export in `my_qdmi/device.h`.
 You only need to add `MY_QDMI_EXPORT` manually for additional custom public functions.
@@ -373,7 +375,8 @@ For quick reference, here are all breaking changes in v1.2.0:
 5. **`QDMI_JOB_STATUS` enum**: Reordered to reflect job lifecycle
 6. **CMake**: Minimum version raised to 3.24
 
-[unreleased]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.2.2...HEAD
+[unreleased]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.2.2...v1.3.0
 [1.2.2]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Munich-Quantum-Software-Stack/QDMI/compare/v1.1.0...v1.2.0

--- a/templates/device/cmake/ExternalDependencies.cmake
+++ b/templates/device/cmake/ExternalDependencies.cmake
@@ -64,17 +64,17 @@ if(BUILD_MY_QDMI_DOCS)
       NEW
       CACHE STRING
             "Set the default CMP0116 policy to NEW for documentation builds")
-  set(DOXYGEN_VERSION
+  set(MIN_DOXYGEN_VERSION
       1.15.0
-      CACHE STRING "Doxygen version")
+      CACHE STRING "Minimum required Doxygen version")
   set(DOXYGEN_REV
-      "7cca38ba5185457e6d9495bf963d4cdeacebc25a"
+      "669aeeefca743c148e2d935b3d3c69535c7491e6" # v1.16.1
       CACHE STRING "Doxygen identifier (tag, branch or commit hash)")
   FetchContent_Declare(
     Doxygen
     GIT_REPOSITORY https://github.com/doxygen/doxygen.git
     GIT_TAG ${DOXYGEN_REV}
-    FIND_PACKAGE_ARGS ${DOXYGEN_VERSION})
+    FIND_PACKAGE_ARGS ${MIN_DOXYGEN_VERSION})
   list(APPEND FETCH_PACKAGES Doxygen)
 
   set(DOXYGEN_AWESOME_VERSION

--- a/templates/device/pyproject.toml
+++ b/templates/device/pyproject.toml
@@ -16,7 +16,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 [build-system]
-requires = ["scikit-build-core>=0.11.6"]
+requires = ["scikit-build-core>=0.12.2"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -163,19 +163,17 @@ convention = "google"
 
 [tool.cibuildwheel]
 build = "cp3*"
-skip = ["cp313t-*"]
 archs = "auto64"
 test-groups = ["test"]
 test-sources = ["test/python"]
 test-command = "pytest test/python"
-build-frontend = "build[uv]"
-enable = ["cpython-freethreading"]
+build-frontend = "uv"
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 
 [tool.cibuildwheel.windows]
-before-build = "uv pip install delvewheel>=1.11.2"
+before-build = "uv pip install delvewheel>=1.12.0"
 repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --namespace-pkg my"
 
 

--- a/templates/device/pyproject.toml
+++ b/templates/device/pyproject.toml
@@ -54,15 +54,15 @@ my-qdmi = "my.qdmi.__main__:main"
 
 [dependency-groups]
 test = [
-  "pytest>=9.0.1",
+  "pytest>=9.0.3",
   "pytest-console-scripts>=1.4.1",
-  "pytest-cov>=7.0.0",
+  "pytest-cov>=7.1.0",
   "pytest-sugar>=1.1.1",
   "pytest-xdist>=3.8.0",
 ]
 dev = [
   {include-group = "test"},
-  "nox>=2025.11.12",
+  "nox>=v2026.4.10",
   "ty==0.0.31",
 ]
 

--- a/templates/device/uv.lock
+++ b/templates/device/uv.lock
@@ -256,18 +256,18 @@ test = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "nox", specifier = ">=2025.11.12" },
-    { name = "pytest", specifier = ">=9.0.1" },
+    { name = "nox", specifier = ">=2026.4.10" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ty", specifier = "==0.0.31" },
 ]
 test = [
-    { name = "pytest", specifier = ">=9.0.1" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-console-scripts", specifier = ">=1.4.1" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
 ]


### PR DESCRIPTION
## Description

This PR prepares the next minor release of QDMI (`v1.3.0`).
The biggest change here is that QDMI device implementations can now be distributed truly standalone, without actually linking to QDMI itself.
In addition, the QDMI device header now explicitly uses symbol exports so that devices may limit symbol visibility to hidden by default.
See the upgrade guide for how to adapt device implementations.

While there are no further breaking changes on the `develop` branch, development of the `v1.3.x` series will continue on the develop branch.

#326 may still make it into this release after this PR.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
