### PR TITLE
:bug: Fix Windows path resolution for the example device and the device template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ clients compiled against a different minor or major version.
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 Fix Windows shared-library detection in the Python wrappers of the example and template device packages by resolving packaged libraries from `bin` instead of only `lib`/`lib64` ([#409]) ([\@marcelwa])
+
 ## [1.3.0] - 2026-04-21
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#130)._
@@ -147,6 +151,7 @@ changelogs._
 
 <!-- PR links -->
 
+[#409]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/409
 [#377]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/377
 [#375]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/375
 [#373]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/373
@@ -191,6 +196,7 @@ changelogs._
 [\@ystade]: https://github.com/ystade
 [\@mnfarooqi]: https://github.com/mnfarooqi
 [\@rainij]: https://github.com/rainij
+[\@marcelwa]: https://github.com/marcelwa
 
 <!-- General links -->
 

--- a/examples/device/python/cxx/qdmi/__init__.py
+++ b/examples/device/python/cxx/qdmi/__init__.py
@@ -17,6 +17,7 @@
 
 """Python wrapper for exposing the CXX QDMI device library."""
 
+import sys
 from importlib.metadata import distribution
 from pathlib import Path
 
@@ -29,6 +30,34 @@ def __dir__() -> list[str]:
     return __all__
 
 
+def _resolve_library_dir() -> Path:
+    """Return the directory containing the packaged CXX QDMI shared library.
+
+    Raises:
+        FileNotFoundError: If the expected library directory does not exist.
+    """
+    if sys.platform == "win32":
+        library_dir = _CXX_QDMI_DATA / "bin"
+        if library_dir.exists():
+            return library_dir
+        msg = f"Expected 'bin' directory for CXX QDMI library on Windows, but it does not exist: {library_dir}"
+        raise FileNotFoundError(msg)
+
+    library_dir = _CXX_QDMI_DATA / "lib"
+    if library_dir.exists():
+        return library_dir
+
+    library_dir = _CXX_QDMI_DATA / "lib64"
+    if library_dir.exists():
+        return library_dir
+
+    msg = (
+        "Expected 'lib' or 'lib64' directory for CXX QDMI library on Unix-like systems, "
+        f"but neither exists: {library_dir}"
+    )
+    raise FileNotFoundError(msg)
+
+
 dist = distribution("cxx-qdmi")
 located_include_dir = dist.locate_file("cxx/qdmi/data/include/cxx_qdmi")
 resolved_include_dir = Path(str(located_include_dir)).resolve(strict=True)
@@ -36,12 +65,9 @@ resolved_include_dir = Path(str(located_include_dir)).resolve(strict=True)
 _CXX_QDMI_DATA = resolved_include_dir.parents[1]
 assert _CXX_QDMI_DATA.exists(), f"CXX_QDMI_DATA does not exist: {_CXX_QDMI_DATA}"
 
-_CXX_QDMI_LIBRARY_DIR = _CXX_QDMI_DATA / "lib"
-if not _CXX_QDMI_LIBRARY_DIR.exists():
-    _CXX_QDMI_LIBRARY_DIR = _CXX_QDMI_DATA / "lib64"
-assert _CXX_QDMI_LIBRARY_DIR.exists(), f"CXX_QDMI_LIBRARY_DIR does not exist: {_CXX_QDMI_LIBRARY_DIR}"
+_CXX_QDMI_LIBRARY_DIR = _resolve_library_dir()
 
-# the library is the sole file in the lib directory
+# the library is the sole file in the packaged library directory
 library_files = list(_CXX_QDMI_LIBRARY_DIR.glob("*cxx-qdmi-device*"))
 if not library_files:
     msg = f"No CXX QDMI library found in: {_CXX_QDMI_LIBRARY_DIR}"

--- a/templates/device/python/my/qdmi/__init__.py
+++ b/templates/device/python/my/qdmi/__init__.py
@@ -17,6 +17,7 @@
 
 """Python wrapper for exposing the MY QDMI device library."""
 
+import sys
 from importlib.metadata import distribution
 from pathlib import Path
 
@@ -29,6 +30,34 @@ def __dir__() -> list[str]:
     return __all__
 
 
+def _resolve_library_dir() -> Path:
+    """Return the directory containing the packaged MY QDMI shared library.
+
+    Raises:
+        FileNotFoundError: If the expected library directory does not exist.
+    """
+    if sys.platform == "win32":
+        library_dir = _MY_QDMI_DATA / "bin"
+        if library_dir.exists():
+            return library_dir
+        msg = f"Expected 'bin' directory for MY QDMI library on Windows, but it does not exist: {library_dir}"
+        raise FileNotFoundError(msg)
+
+    library_dir = _MY_QDMI_DATA / "lib"
+    if library_dir.exists():
+        return library_dir
+
+    library_dir = _MY_QDMI_DATA / "lib64"
+    if library_dir.exists():
+        return library_dir
+
+    msg = (
+        "Expected 'lib' or 'lib64' directory for MY QDMI library on Unix-like systems, "
+        f"but neither exists: {library_dir}"
+    )
+    raise FileNotFoundError(msg)
+
+
 dist = distribution("my-qdmi")
 located_include_dir = dist.locate_file("my/qdmi/data/include/my_qdmi")
 resolved_include_dir = Path(str(located_include_dir)).resolve(strict=True)
@@ -36,12 +65,9 @@ resolved_include_dir = Path(str(located_include_dir)).resolve(strict=True)
 _MY_QDMI_DATA = resolved_include_dir.parents[1]
 assert _MY_QDMI_DATA.exists(), f"MY_QDMI_DATA does not exist: {_MY_QDMI_DATA}"
 
-_MY_QDMI_LIBRARY_DIR = _MY_QDMI_DATA / "lib"
-if not _MY_QDMI_LIBRARY_DIR.exists():
-    _MY_QDMI_LIBRARY_DIR = _MY_QDMI_DATA / "lib64"
-assert _MY_QDMI_LIBRARY_DIR.exists(), f"MY_QDMI_LIBRARY_DIR does not exist: {_MY_QDMI_LIBRARY_DIR}"
+_MY_QDMI_LIBRARY_DIR = _resolve_library_dir()
 
-# the library is the sole file in the lib directory
+# the library is the sole file in the packaged library directory
 library_files = list(_MY_QDMI_LIBRARY_DIR.glob("*my-qdmi-device*"))
 if not library_files:
     msg = f"No MY QDMI library found in: {_MY_QDMI_LIBRARY_DIR}"


### PR DESCRIPTION
## Description

The path resolution for locating the packaged QDMI shared library in the example device and the device template was too optimistic and didn't account for Windows quirks. This PR fixes that oversight by adding a dedicated Windows route.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or
      removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
