### PR TITLE
📝 Publish Doxygen tag files with documentation

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -21,12 +21,13 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name || inputs.version }}
 
-      - name: Fetch version selector scripts from develop 📝
+      - name: Fetch documentation tooling from develop 📝
         run: |
-          # Fetch and checkout the scripts from develop branch
+          # Fetch tag-file generation and version-selector tooling from develop.
+          # This also allows existing releases to be rebuilt with tag files.
           git fetch origin develop
           mkdir -p .github/scripts
-          git checkout origin/develop -- .github/scripts/inject-version-selector.sh .github/scripts/version-selector.html || echo "Scripts not found in develop, will skip version selector"
+          git checkout origin/develop -- docs/CMakeLists.txt docs/Doxyfile.in .github/scripts/inject-version-selector.sh .github/scripts/version-selector.html || echo "Documentation tooling not found in develop"
 
       - name: Install Doxygen
         uses: ssciwr/doxygen-install@329d88f5a303066a5bd006db7516b1925b86350e # v2.0.1
@@ -38,6 +39,7 @@ jobs:
           cmake -S . -B build -DBUILD_QDMI_DOCS=ON
           cmake --build build --target qdmi-docs
           mv build/docs/html/ static
+          cp build/docs/qdmi.tag static/qdmi.tag
 
       - name: Set version variable
         id: version

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -22,6 +22,7 @@ jobs:
           cmake -S . -B build -DBUILD_QDMI_DOCS=ON
           cmake --build build --target qdmi-docs
           mv build/docs/html/ static
+          cp build/docs/qdmi.tag static/qdmi.tag
       - name: Inject version selector
         if: github.event.action != 'closed'
         run: |

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -73,6 +73,7 @@ string(REPLACE ";" " " DOXYGEN_EXAMPLE_DIRS "${DOXYGEN_EXAMPLE_DIRS}")
 # Set the output directory for the generated documentation: Place it in the
 # CMake build directory.
 set(DOXYGEN_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(DOXYGEN_TAG_FILE ${DOXYGEN_OUTPUT_DIR}/qdmi.tag)
 
 # Set the Doxygen configured configuration file. This will point to the Doxyfile
 # that is written out by CMake with all placeholders substituted.
@@ -108,7 +109,7 @@ endif()
 
 # Create a custom command to run Doxygen
 add_custom_command(
-  OUTPUT ${DOXYGEN_OUTPUT_DIR}/html/index.html
+  OUTPUT ${DOXYGEN_OUTPUT_DIR}/html/index.html ${DOXYGEN_TAG_FILE}
   DEPENDS ${DOXYGEN_INPUT_FILES}
           ${DOXYGEN_CONFIG_FILE_IN}
           ${CMAKE_CURRENT_SOURCE_DIR}/ai_usage.md
@@ -126,4 +127,5 @@ add_custom_command(
   VERBATIM)
 
 # Create a custom target
-add_custom_target(qdmi-docs ALL DEPENDS ${DOXYGEN_OUTPUT_DIR}/html/index.html)
+add_custom_target(qdmi-docs ALL DEPENDS ${DOXYGEN_OUTPUT_DIR}/html/index.html
+                                        ${DOXYGEN_TAG_FILE})

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -2520,7 +2520,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = @DOXYGEN_TAG_FILE@
 
 # If the ALLEXTERNALS tag is set to YES, all external classes and namespaces
 # will be listed in the class and namespace index. If set to NO, only the


### PR DESCRIPTION
## Summary

- generate `qdmi.tag` alongside the native Doxygen HTML
- deploy the tag file with `latest/` and each versioned documentation release
- enable release-docs rebuilds to backfill tag files for existing releases

## Why

Downstream documentation, such as MQT Core, can consume QDMI's Doxygen tag
file to resolve `QDMI_*` references to the matching versioned API pages. This
avoids re-parsing the C/C++ API through Sphinx/Breathe while retaining direct
cross-project API links.

## Validation

- `cmake -S . -B build -DBUILD_QDMI_DOCS=ON -DBUILD_QDMI_TESTS=OFF -DBUILD_QDMI_EXAMPLES=OFF -DBUILD_QDMI_TEMPLATES=OFF`
- `cmake --build build --target qdmi-docs`
- verified `build/docs/qdmi.tag` is non-empty and contains `QDMI_device_initialize`
- `prek run --all-files`
