### PR TITLE
📝 Add repository agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,8 @@ with CMake `FetchContent`.
 - MUST run `uvx prek run -a` after every batch of changes. All hooks from
   `.pre-commit-config.yaml` must pass before submitting.
 - MUST add or update tests for every code change, including bug fixes.
-- MUST follow existing patterns in neighboring files and keep changes focused
-  on one feature or bug.
+- MUST follow existing patterns in neighboring files and keep changes focused on
+  one feature or bug.
 - MUST update `CHANGELOG.md` for noteworthy or user-facing changes and
   `UPGRADING.md` for breaking changes.
 - MUST follow `docs/ai_usage.md`: a human must review and understand all
@@ -78,8 +78,8 @@ with CMake `FetchContent`.
   `cmake/GenerateTemplate.cmake`.
 - When changing the template, build and test its instantiated targets as well as
   the main QDMI test suite.
-- Keep example implementations representative of the public interface and
-  update them when interface changes require it.
+- Keep example implementations representative of the public interface and update
+  them when interface changes require it.
 
 ## Self-Review Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,8 @@ with CMake `FetchContent`.
 - MUST document new user-facing behavior, update `CHANGELOG.md` for noteworthy
   changes, and update `UPGRADING.md` for breaking changes.
 - MUST follow `docs/ai_usage.md`: a human must review and understand all
-  AI-assisted work, and AI assistance must not be used for `good first issue`
-  contributions, issue descriptions, PR comments, or code reviews.
+  AI-assisted work. AI assistance must not be used for `good first issue`
+  contributions.
 - MUST include a commit footer attribution in the form
   `Assisted-by: [Model Name] via [Tool Name]` when AI tools helped prepare a
   commit.
@@ -59,13 +59,21 @@ with CMake `FetchContent`.
   relevant preset before handoff.
 - NEVER edit generated build output or dependency source trees under `build/`.
 
-### GitHub Pull Requests
+### GitHub Issues and Pull Requests
 
-- MAY create or edit a pull request only when the user explicitly requests it;
-  the human remains responsible for reviewing all submitted work.
+- MAY create, submit, and edit pull requests; create and manage issues; and
+  comment on issues or pull requests when the task explicitly authorizes that
+  external action. The human remains responsible for reviewing all submitted
+  work.
 - MUST use the repository's pull request template when one is present.
-- MUST NOT use AI tools to generate issue descriptions, pull request comments,
-  or code reviews, as required by `docs/ai_usage.md`.
+- Every agent-authored or agent-edited public text MUST begin with
+  `🤖 *AI text below* 🤖` on its first line. This applies to issue and pull
+  request descriptions, review bodies, inline review comments, issue comments,
+  replies, and other submitted text bodies; titles are exempt.
+- When editing human-authored public text, preserve its original content and add
+  the disclosure at the beginning of the edited field.
+- MUST keep external communication accurate, specific, and non-repetitive; do
+  not post low-quality or unsolicited comments.
 
 ### C and C++
 
@@ -102,3 +110,5 @@ with CMake `FetchContent`.
 - Were `CHANGELOG.md` and `UPGRADING.md` updated when appropriate?
 - Were template and example consumers updated and tested when the interface or
   generation behavior changed?
+- Were any agent-authored issue or pull request texts explicitly authorized and
+  marked with the required visible disclosure?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# QDMI
+
+## Build and Test
+
+- Configure: `cmake --preset release`
+- Build: `cmake --build --preset release`
+- Test: `ctest --preset release`
+- Single test binary: `./build/release/test/qdmi_test`
+- For debug builds, replace `release` with `debug`.
+- For coverage, use the `coverage` configure, build, and test presets.
+- For all available options and presets, see `CMakeLists.txt` and
+  `CMakePresets.json`.
+
+The first configure may need network access because dependencies are managed
+with CMake `FetchContent`.
+
+## Documentation
+
+- Sources: `docs/`
+- Configure: `cmake -S . -B build/docs -G Ninja -DBUILD_QDMI_DOCS=ON`
+- Build: `cmake --build build/docs --target qdmi-docs`
+- Generated HTML: `build/docs/docs/html/index.html`
+
+## Tech Stack and Layout
+
+- Public interface: C11 headers in `include/qdmi/`
+- Tests and example implementations: C++20
+- Build system: CMake 3.24+ with presets and `FetchContent`
+- Unit tests: GoogleTest in `test/`
+- Example device, driver, tool, and FoMaC implementations: `examples/`
+- Device project source template: `templates/device/`
+- Documentation: Doxygen with Markdown sources in `docs/`
+- Formatting and checks: `prek`, `clang-format`, `cmake-format`, `rumdl`,
+  `typos`, and license checks
+- Static analysis: `clang-tidy`
+
+## Development Guidelines
+
+### General
+
+- MUST run `uvx prek run -a` after every batch of changes. All hooks from
+  `.pre-commit-config.yaml` must pass before submitting.
+- MUST add or update tests for every code change, including bug fixes.
+- MUST follow existing patterns in neighboring files and keep changes focused
+  on one feature or bug.
+- MUST update `CHANGELOG.md` for noteworthy or user-facing changes and
+  `UPGRADING.md` for breaking changes.
+- MUST follow `docs/ai_usage.md`: a human must review and understand all
+  AI-assisted work, and AI assistance must not be used for `good first issue`
+  contributions, issue descriptions, PR comments, or code reviews.
+- MUST include a commit footer attribution in the form
+  `Assisted-by: [Model Name] via [Tool Name]` when AI tools helped prepare a
+  commit.
+- MUST preserve the Apache-2.0-with-LLVM-exception license headers used by the
+  surrounding source files.
+- PREFER targeted builds and tests during development, then run the full
+  relevant preset before handoff.
+- NEVER edit generated build output or dependency source trees under `build/`.
+
+### C and C++
+
+- MUST keep the public QDMI interface C11-compatible.
+- MUST use C++20 for tests and example implementations.
+- MUST follow the LLVM coding style and the repository's `.clang-format` and
+  `.clang-tidy` configurations.
+- MUST use Doxygen-style API comments. Provide `@brief`, document every
+  parameter with `@param`, and document non-void return values with `@return`.
+- MUST add new public headers below `include/qdmi/` and cover API changes in
+  `test/`.
+- PREFER existing QDMI status codes, types, naming, and ownership patterns over
+  introducing parallel abstractions.
+
+### Templates and Examples
+
+- Treat `templates/device/` as the source for generated device projects; update
+  the source template when changing generated-project behavior.
+- Keep template placeholder forms (`MY`, `my_`, and `my-`) consistent with
+  `cmake/GenerateTemplate.cmake`.
+- When changing the template, build and test its instantiated targets as well as
+  the main QDMI test suite.
+- Keep example implementations representative of the public interface and
+  update them when interface changes require it.
+
+## Self-Review Checklist
+
+- Did the relevant configure and build preset succeed?
+- Did targeted tests and `ctest --preset <preset>` pass?
+- Did `uvx prek run -a` pass without errors?
+- Are all behavior changes covered by automated tests?
+- Does the public interface remain C11-compatible?
+- Were Doxygen comments and documentation updated for API changes?
+- Were `CHANGELOG.md` and `UPGRADING.md` updated when appropriate?
+- Were template and example consumers updated and tested when the interface or
+  generation behavior changed?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,13 +38,14 @@ with CMake `FetchContent`.
 
 ### General
 
+- MUST read and follow `docs/contributing.md` before making a contribution.
 - MUST run `uvx prek run -a` after every batch of changes. All hooks from
   `.pre-commit-config.yaml` must pass before submitting.
 - MUST add or update tests for every code change, including bug fixes.
 - MUST follow existing patterns in neighboring files and keep changes focused on
-  one feature or bug.
-- MUST update `CHANGELOG.md` for noteworthy or user-facing changes and
-  `UPGRADING.md` for breaking changes.
+  one feature or bug; avoid unrelated refactors or formatting changes.
+- MUST document new user-facing behavior, update `CHANGELOG.md` for noteworthy
+  changes, and update `UPGRADING.md` for breaking changes.
 - MUST follow `docs/ai_usage.md`: a human must review and understand all
   AI-assisted work, and AI assistance must not be used for `good first issue`
   contributions, issue descriptions, PR comments, or code reviews.
@@ -53,9 +54,18 @@ with CMake `FetchContent`.
   commit.
 - MUST preserve the Apache-2.0-with-LLVM-exception license headers used by the
   surrounding source files.
+- NEVER expose, print, store, or commit credentials, tokens, or other secrets.
 - PREFER targeted builds and tests during development, then run the full
   relevant preset before handoff.
 - NEVER edit generated build output or dependency source trees under `build/`.
+
+### GitHub Pull Requests
+
+- MAY create or edit a pull request only when the user explicitly requests it;
+  the human remains responsible for reviewing all submitted work.
+- MUST use the repository's pull request template when one is present.
+- MUST NOT use AI tools to generate issue descriptions, pull request comments,
+  or code reviews, as required by `docs/ai_usage.md`.
 
 ### C and C++
 

--- a/docs/ai_usage.md
+++ b/docs/ai_usage.md
@@ -28,41 +28,57 @@ not submit it.
 
 ### 2. Human in the Loop {#human-in-the-loop}
 
-**Autonomous contributions from AI agents are not allowed.**
+**Humans remain accountable for AI-assisted contributions.**
 
-When using AI tools, you must be the driver. The AI is the assistant.
+AI agents may implement changes and manage issue and pull request workflows when
+a human explicitly authorizes the scope and relevant external actions. The human
+remains the driver and is responsible for the resulting contribution.
 
-- **Review:** You must read and review all AI-generated code or text before
-  submitting it.
+- **Review:** You must read and review all AI-generated code or public text
+  before submitting it, merging it, or otherwise representing it as your own
+  work.
 - **Edit:** AI-generated code often requires significant editing to meet project
   standards and correctness.
 - **Verify:** Ensure the code actually solves the problem and doesn't introduce
   subtle bugs or security vulnerabilities.
+- **Authorize:** Explicitly authorize agents before they create, edit, submit,
+  or comment on issues and pull requests. Remain accountable for all external
+  communication that they submit on your behalf.
 
 ### 3. Communication {#communication}
 
-**Do not use AI tools to generate issue descriptions, pull request comments, or
-code reviews.**
+**AI tools may be used to prepare and manage issue and pull request workflows,
+including descriptions, comments, and code reviews, when a human has authorized
+the action and remains responsible for the result.**
 
-We value your personal input and communication. LLMs are notoriously unreliable
-and can produce "smart-sounding" but incorrect or irrelevant claims
-("hallucinations"). Phrase your communications in your own words. It is more
-important that we can follow your reasoning than that the text sounds "perfect".
+AI-generated communication can be incorrect, irrelevant, or overly generic. Keep
+it accurate, specific, and useful to reviewers and contributors. Do not post
+low-quality, repetitive, or unsolicited messages.
+
+Every agent-authored or agent-edited public text body must begin with the
+following visible disclosure:
+
+`🤖 *AI text below* 🤖`
+
+This requirement applies to issue and pull request descriptions, review bodies,
+inline review comments, issue-style comments, replies, and other submitted text
+bodies. Pull request and issue titles are exempt. When editing existing
+human-authored text, preserve the original content and add the disclosure at the
+beginning of the edited field.
 
 ### 4. Transparency and Disclosure {#transparency-and-disclosure}
 
 Transparency helps the community understand the role of these tools and develop
 best practices.
 
-**We encourage you to disclose any AI assistance.** This helps us understand how
-these tools are being used and identify potential issues. You can disclose this
-information in the following ways:
+**You must disclose AI assistance.** This helps us understand how the tools are
+being used and identify potential issues. Disclose it in the following ways:
 
 - **Commit Messages**: Add a trailer to your commit message in the form
   `Assisted-by: [Model Name] via [Tool Name]` (example:
   `Assisted-by: Claude Sonnet 4.6 via GitHub Copilot`)
-- **PR Description**: Mention the tool (name and version) and how it was used in
-  the PR description.
+- **Public issue and pull request text**: Use the visible disclosure required in
+  the [communication policy](#communication).
 
 ### 5. Licensing and Copyright {#licensing-and-copyright}
 
@@ -121,8 +137,8 @@ its contributors can thrive.
 - **"Good First Issues"**: Do not use AI tools to solve issues labeled as "good
   first issue". These are intended as learning opportunities for new
   contributors. Automating them defeats the purpose.
-- **Spam**: Do not use AI to generate low-quality or repetitive comments/reviews
-  ("AI Slop").
+- **Spam**: Do not use AI to generate low-quality, repetitive, or unsolicited
+  comments or reviews ("AI Slop").
 - **Unreviewed Code**: Submitting code that you, as a human, have not reviewed
   and tested yourself.
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- add a repository-level `AGENTS.md`
- document QDMI build, test, documentation, style, template, and contribution conventions
- enable explicitly authorized AI management of issues and pull requests
- require visible disclosure for agent-authored public issue and pull request text

## Impact

This gives coding agents repository-specific guidance while preserving human accountability, review, and quality expectations.

## Validation

- `uvx prek run -a`

Assisted-by: GPT-5 via Codex
