### PR TITLE
👷 Test generated templates against the exact QDMI revision

### DIFF
--- a/.github/workflows/reusable-template-ci.yml
+++ b/.github/workflows/reusable-template-ci.yml
@@ -10,6 +10,10 @@ jobs:
     name: Build Device Template
     runs-on: ubuntu-24.04
     env:
+      CIBW_ENVIRONMENT_PASS_LINUX: CMAKE_ARGS
+      CMAKE_ARGS: >-
+        -DQDMI_REPO_OWNER=${{ github.event.pull_request.head.repo.owner.login || github.repository_owner }}
+        -DQDMI_REV=${{ github.event.pull_request.head.sha || github.sha }}
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
@@ -40,7 +44,7 @@ jobs:
           git commit -m "🎉 Initial commit"
       - name: Build template
         run: |
-          cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_MQSS_QDMI_TESTS=ON
+          cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_MQSS_QDMI_TESTS=ON $CMAKE_ARGS
           cmake --build build --config Release
       - name: Install Doxygen
         uses: ssciwr/doxygen-install@b5b80f5a60852f72d3c33f47fee9ddfb84a25929 # v2.0.2
@@ -48,7 +52,7 @@ jobs:
           version: "1.15.0"
       - name: Build docs
         run: |
-          cmake -G Ninja -S . -B build_docs -DCMAKE_BUILD_TYPE=Release -DBUILD_MQSS_QDMI_DOCS=ON -DBUILD_MQSS_QDMI_TESTS=OFF
+          cmake -G Ninja -S . -B build_docs -DCMAKE_BUILD_TYPE=Release -DBUILD_MQSS_QDMI_DOCS=ON -DBUILD_MQSS_QDMI_TESTS=OFF $CMAKE_ARGS
           cmake --build build_docs --config Release --target mqss_qdmi_device_docs
           rm -rf build_docs
       - uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Make the reusable template CI build generated projects against the exact QDMI
repository owner and revision being tested.

The job previously generated a standalone project and then fetched mutable
`develop`. This caused QDMI #475 to fail because its generated project used
functionality introduced by that pull request but absent from `develop`. The
workflow now passes the pull request head owner and SHA to the direct CMake
builds and forwards the same `CMAKE_ARGS` into cibuildwheel's Linux containers.
Push and merge-queue events fall back to the current repository owner and event
SHA.

The generated template and its normal dependency defaults remain unchanged.
This is a CI-only correction that also makes future template changes test their
exact source revision.

Related to #475.

## Validation

- `uvx prek run -a`
- Generated the #475 device template and built it as a standalone CMake project
  against exact head `c5564bc7a031f6716a4e7bc105ad7aadb4cd79f9`
- Built the generated Python wheel with the same exact-revision `CMAKE_ARGS`
- Independent read-only review of the final diff

## Checklist

- [x] The pull request only contains commits that are focused and relevant to
  this change.
- [x] The reusable template CI job directly covers the changed behavior.
- [x] Documentation changes are not required for this CI-only correction.
- [x] A changelog entry is not warranted because there is no user-facing
  behavior change.
- [x] Migration instructions are not needed.
- [x] The changes follow the project's style guidelines and introduce no new
  warnings.
- [x] The changes passed the relevant local validation listed above.
- [x] The code changes have been independently reviewed.

**If PR contains AI-assisted content:**

- [x] AI assistance is disclosed at the beginning of this description.
- [x] The AI-assisted commit includes the required `Assisted-by` footer.
- [x] A human maintainer has personally reviewed and understood all AI-assisted
  content and accepts responsibility for it.
