### PR TITLE
👷 Align aggregate checks with closed pull request jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,16 @@ jobs:
         with:
           allowed-skips: >-
             ${{
-              !fromJSON(needs.change-detection.outputs.run-tests)
+              (github.event.action == 'closed'
+              || !fromJSON(needs.change-detection.outputs.run-tests))
               && 'tests,' || ''
             }} ${{
-              !fromJSON(needs.change-detection.outputs.run-linter)
+              (github.event.action == 'closed'
+              || !fromJSON(needs.change-detection.outputs.run-linter))
               && 'linter,' || ''
             }} ${{
-              !fromJSON(needs.change-detection.outputs.run-template)
+              (github.event.action == 'closed'
+              || !fromJSON(needs.change-detection.outputs.run-template))
               && 'template,' || ''
             }} ${{
              !fromJSON(needs.change-detection.outputs.run-docs)


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Allow the aggregate `🚦 Check` job to accept skipped test, lint, and template
jobs on `pull_request: closed` events.

The producer jobs already skip closed pull requests, while the aggregate job
previously allowed skips only when change detection marked a job irrelevant.
After #476 merged, change detection correctly marked template CI as relevant,
the template job skipped because the event was `closed`, and the aggregate job
incorrectly treated that skip as a failure in
[run 30399676581](https://github.com/Munich-Quantum-Software-Stack/QDMI/actions/runs/30399676581).

The allowed-skip expressions now mirror the producer job conditions: tests,
lint, and templates may skip on closed events or when their path filters disable
them. Documentation remains unchanged because its closed-event path may remove
the pull request preview. Other pull request events, pushes, merge-group runs,
and manual runs continue to require every relevant job.

## Validation

- `uvx prek run -a`
- `git diff --check`
- Independent read-only review of the closed/non-closed event truth table and
  documentation cleanup path

The definitive hosted regression check is this pull request's own `closed` run
after merge.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to
  this change.
- [x] The workflow's existing aggregate gate covers the changed behavior.
- [x] Documentation changes are not required for this CI-only correction.
- [x] A changelog entry is not warranted because there is no user-facing
  behavior change.
- [x] Migration instructions are not needed.
- [x] The changes follow the project's style guidelines and introduce no new
  warnings.
- [x] The changes passed the relevant local validation listed above.
- [x] The code changes have been independently reviewed.

**If PR contains AI-assisted content:**

- [x] AI assistance is disclosed at the beginning of this description.
- [x] The AI-assisted commit includes the required `Assisted-by` footer.
- [x] A human maintainer has personally reviewed and understood all AI-assisted
  content and accepts responsibility for it.
