### PR TITLE
✨ Add queue length and job position properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ clients compiled against a different minor or major version.
 
 ### Added
 
+- ✨ Add an optional device property for querying the current queue depth
+  ([#486]) ([\@burgholzer])
 - 👨‍💻 Add stable device IDs and symbol-prefix metadata to exported device targets
   and generated projects ([#475]) ([\@burgholzer])
 
@@ -209,6 +211,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#486]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/486
 [#475]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/475
 [#457]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/457
 [#456]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/456

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ clients compiled against a different minor or major version.
 
 ### Added
 
-- ✨ Add an optional device property for querying the current queue depth
-  ([#486]) ([\@burgholzer])
+- ✨ Add optional properties for querying a device's current queue length and a
+  queued job's current queue position ([#486]) ([\@burgholzer])
 - 👨‍💻 Add stable device IDs and symbol-prefix metadata to exported device targets
   and generated projects ([#475]) ([\@burgholzer])
 

--- a/include/qdmi/client.h
+++ b/include/qdmi/client.h
@@ -776,6 +776,21 @@ enum QDMI_JOB_PROPERTY_T {
    */
   QDMI_JOB_PROPERTY_SHOTSNUM = 3,
   /**
+   * @brief `size_t` The current number of jobs ahead of this job in its queue.
+   * @details Querying this property must refresh the job's status and queue
+   * position. The property can only be queried while the refreshed status is
+   * @ref QDMI_JOB_STATUS_QUEUED; otherwise, the query must return @ref
+   * QDMI_ERROR_BADSTATE.
+   * @par
+   * If the provider only exposes a lower bound, the implementation reports
+   * that lower bound. For example, a provider value of `>50` is reported as
+   * `50`.
+   * @par
+   * The property may yield @ref QDMI_ERROR_NOTSUPPORTED if the implementation
+   * cannot obtain a trustworthy queue position.
+   */
+  QDMI_JOB_PROPERTY_QUEUEPOSITION = 4,
+  /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
    * function parameters.
@@ -783,7 +798,7 @@ enum QDMI_JOB_PROPERTY_T {
    * @attention This value must remain the last regular member of the enum
    * besides the custom members and must be updated when new members are added.
    */
-  QDMI_JOB_PROPERTY_MAX = 4,
+  QDMI_JOB_PROPERTY_MAX = 5,
   /**
    * @brief This enum value is reserved for a custom parameter.
    * @details The driver defines the meaning and the type of this parameter.

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -430,6 +430,21 @@ enum QDMI_DEVICE_PROPERTY_T {
    */
   QDMI_DEVICE_PROPERTY_CHILDDEVICES = 16,
   /**
+   * @brief `size_t` The current number of jobs waiting to access the device.
+   * @details This property is a snapshot of the device's queue depth and does
+   * not include jobs that are currently executing. If a provider exposes
+   * multiple queues for the device, the implementation reports the sum of the
+   * waiting jobs across those queues.
+   * @par
+   * If the provider only exposes a lower bound, the implementation reports
+   * that lower bound. For example, a provider value of `>50` is reported as
+   * `50`.
+   * @par
+   * The property may yield @ref QDMI_ERROR_NOTSUPPORTED if the implementation
+   * cannot obtain a trustworthy queue depth.
+   */
+  QDMI_DEVICE_PROPERTY_QUEUEDEPTH = 17,
+  /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
    * function parameters.
@@ -437,7 +452,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @attention This value must remain the last regular member of the enum
    * besides the custom members and must be updated when new members are added.
    */
-  QDMI_DEVICE_PROPERTY_MAX = 17,
+  QDMI_DEVICE_PROPERTY_MAX = 18,
   /**
    * @brief This enum value is reserved for a custom property.
    * @details The device defines the meaning and the type of this property.

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -253,6 +253,21 @@ enum QDMI_DEVICE_JOB_PROPERTY_T {
    */
   QDMI_DEVICE_JOB_PROPERTY_SHOTSNUM = 3,
   /**
+   * @brief `size_t` The current number of jobs ahead of this job in its queue.
+   * @details Querying this property must refresh the job's status and queue
+   * position. The property can only be queried while the refreshed status is
+   * @ref QDMI_JOB_STATUS_QUEUED; otherwise, the query must return @ref
+   * QDMI_ERROR_BADSTATE.
+   * @par
+   * If the provider only exposes a lower bound, the implementation reports
+   * that lower bound. For example, a provider value of `>50` is reported as
+   * `50`.
+   * @par
+   * The property may yield @ref QDMI_ERROR_NOTSUPPORTED if the implementation
+   * cannot obtain a trustworthy queue position.
+   */
+  QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION = 4,
+  /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
    * function parameters.
@@ -260,7 +275,7 @@ enum QDMI_DEVICE_JOB_PROPERTY_T {
    * @attention This value must remain the last regular member of the enum
    * besides the custom members and must be updated when new members are added.
    */
-  QDMI_DEVICE_JOB_PROPERTY_MAX = 4,
+  QDMI_DEVICE_JOB_PROPERTY_MAX = 5,
   /**
    * @brief This enum value is reserved for a custom parameter.
    * @details The device defines the meaning and the type of this parameter.
@@ -431,7 +446,7 @@ enum QDMI_DEVICE_PROPERTY_T {
   QDMI_DEVICE_PROPERTY_CHILDDEVICES = 16,
   /**
    * @brief `size_t` The current number of jobs waiting to access the device.
-   * @details This property is a snapshot of the device's queue depth and does
+   * @details This property is a snapshot of the device's queue length and does
    * not include jobs that are currently executing. If a provider exposes
    * multiple queues for the device, the implementation reports the sum of the
    * waiting jobs across those queues.
@@ -441,9 +456,9 @@ enum QDMI_DEVICE_PROPERTY_T {
    * `50`.
    * @par
    * The property may yield @ref QDMI_ERROR_NOTSUPPORTED if the implementation
-   * cannot obtain a trustworthy queue depth.
+   * cannot obtain a trustworthy queue length.
    */
-  QDMI_DEVICE_PROPERTY_QUEUEDEPTH = 17,
+  QDMI_DEVICE_PROPERTY_QUEUELENGTH = 17,
   /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -413,6 +413,11 @@ TEST_P(QDMIImplementationTest, QueryDeviceProperties) {
           device, QDMI_DEVICE_PROPERTY_MINATOMDISTANCE, 0, nullptr, nullptr),
       QDMI_ERROR_NOTSUPPORTED);
 
+  // Queue depth is optional and is not supported by the example device
+  EXPECT_EQ(QDMI_device_query_device_property(
+                device, QDMI_DEVICE_PROPERTY_QUEUEDEPTH, 0, nullptr, nullptr),
+            QDMI_ERROR_NOTSUPPORTED);
+
   // The MAX property is not a valid value for any device.
   EXPECT_EQ(QDMI_device_query_device_property(device, QDMI_DEVICE_PROPERTY_MAX,
                                               0, nullptr, nullptr),

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -413,9 +413,9 @@ TEST_P(QDMIImplementationTest, QueryDeviceProperties) {
           device, QDMI_DEVICE_PROPERTY_MINATOMDISTANCE, 0, nullptr, nullptr),
       QDMI_ERROR_NOTSUPPORTED);
 
-  // Queue depth is optional and is not supported by the example device
+  // Queue length is optional and is not supported by the example device
   EXPECT_EQ(QDMI_device_query_device_property(
-                device, QDMI_DEVICE_PROPERTY_QUEUEDEPTH, 0, nullptr, nullptr),
+                device, QDMI_DEVICE_PROPERTY_QUEUELENGTH, 0, nullptr, nullptr),
             QDMI_ERROR_NOTSUPPORTED);
 
   // The MAX property is not a valid value for any device.
@@ -548,6 +548,10 @@ TEST_P(QDMIImplementationTest, JobLifecycle) {
                                     sizeof(size_t), &shots, nullptr),
             QDMI_SUCCESS);
   EXPECT_EQ(shots, 5);
+  // Queue position is optional and is not supported by the example device.
+  EXPECT_EQ(QDMI_job_query_property(job, QDMI_JOB_PROPERTY_QUEUEPOSITION, 0,
+                                    nullptr, nullptr),
+            QDMI_ERROR_NOTSUPPORTED);
   ASSERT_EQ(QDMI_job_submit(job), QDMI_SUCCESS);
   EXPECT_EQ(QDMI_job_submit(job), QDMI_ERROR_INVALIDARGUMENT);
   EXPECT_EQ(QDMI_job_submit(nullptr), QDMI_ERROR_INVALIDARGUMENT);


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Add two optional queue-inspection properties:

- `QDMI_DEVICE_PROPERTY_QUEUELENGTH` reports a `size_t` snapshot of jobs waiting to access a device. It excludes executing jobs, sums multiple provider queues, and preserves a provider lower bound such as `>50` as `50`.
- `QDMI_DEVICE_JOB_PROPERTY_QUEUEPOSITION` and `QDMI_JOB_PROPERTY_QUEUEPOSITION` report the current number of jobs ahead of a queued job. Every property query must refresh the job status and queue position. A refreshed non-queued job returns `QDMI_ERROR_BADSTATE`; a queued job without a trustworthy position returns `QDMI_ERROR_NOTSUPPORTED`.

This adopts `QUEUELENGTH`, as agreed in the review thread, and adds the matching device/client job contract needed by generic consumers and vendor implementations.

## Validation

- `uvx prek run --all-files`
- `cmake --preset release`
- `cmake --build --preset release`
- `ctest --preset release` (101/101 passed)

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (not needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the local checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://munich-quantum-software-stack.github.io/QDMI/latest/md_docs_2ai__usage.html).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
