### PR TITLE
📝 Document exception-safe C entry points

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -101,6 +101,13 @@ computation path at the end that returns \ref QDMI_ERROR_NOTIMPLEMENTED.
 Instead, some other error code from \ref QDMI_STATUS should be returned in case
 of an erroneous state.
 
+QDMI entry points have C linkage, so exceptions must not escape them. Catch
+exceptions directly at entry points that call throwing C++ code, map
+`std::bad_alloc` to \ref QDMI_ERROR_OUTOFMEM, and map unexpected exceptions to
+\ref QDMI_ERROR_FATAL. Catch provider-specific exceptions first when a more
+precise QDMI status applies. A function-try-block keeps this boundary local and
+does not require wrapping non-throwing entry points.
+
 The implementation in the `src/` directory is complemented with a testing
 framework in `test/`. The `.cpp` source file already contains some examples for
 tests. They are meant to serve as an inspiration, and more tests should be

--- a/templates/device/README.md
+++ b/templates/device/README.md
@@ -21,6 +21,12 @@ The exported CMake target publishes the stable device ID configured through
 to package and register the device without project-specific loader code. This
 metadata does not add MQT Core as a dependency.
 
+Do not allow C++ exceptions to escape the device's C entry points. Contain them
+directly at entry points that call throwing code, for example with a
+function-try-block. Map allocation failures to `QDMI_ERROR_OUTOFMEM`, unexpected
+exceptions to `QDMI_ERROR_FATAL`, and provider-specific failures to the most
+precise available status. Non-throwing entry points need no wrapper.
+
 ## Documentation
 
 The full documentation, including project guides, a contributing guide, and the


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Document that C++ exceptions must be contained directly at QDMI C entry points that call throwing implementation code. The guidance recommends a local function-try-block, maps allocation failures to `QDMI_ERROR_OUTOFMEM` and unexpected exceptions to `QDMI_ERROR_FATAL`, and leaves provider-specific mappings to each device.

The generated stubs are non-throwing, so this revision deliberately adds no helper framework, generated lambdas, CMake plumbing, bespoke tests, or CI. Device implementations add containment only where their actual fallible boundaries require it.

Validation:

- full workspace, example-device, and template `prek` suites
- `git diff --check`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] No tests are needed for this documentation-only change.
- [x] I have updated the documentation to reflect these changes.
- [x] No changelog entry is needed for template implementation guidance.
- [x] No migration instructions are needed.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://munich-quantum-software-stack.github.io/QDMI/latest/md_docs_2ai__usage.html).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
