### PR TITLE
🔧 Sync pre-commit configurations of template and example

### DIFF
--- a/examples/device/.pre-commit-config.yaml
+++ b/examples/device/.pre-commit-config.yaml
@@ -30,21 +30,21 @@ repos:
 
   ## Check JSON schemata
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.3
+    rev: 0.38.0
     hooks:
       - id: check-github-workflows
         priority: 0
 
   ## Check pyproject.toml file
   - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: 2026.06.26
+    rev: 2026.08.15
     hooks:
       - id: validate-pyproject
         priority: 0
 
   ## Ensure uv.lock is up to date
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.25
+    rev: 0.12.5
     hooks:
       - id: uv-lock
         priority: 0
@@ -61,7 +61,7 @@ repos:
 
   ## Check for typos
   - repo: https://github.com/adhtruong/mirrors-typos
-    rev: v1.47.2
+    rev: v1.49.0
     hooks:
       - id: typos
         priority: 3
@@ -75,7 +75,7 @@ repos:
 
   ## Format configuration files with prettier
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.9.1
+    rev: v3.9.6
     hooks:
       - id: prettier
         types_or: [yaml, html, css, scss, javascript, json, json5]
@@ -84,7 +84,7 @@ repos:
 
     ## Format Markdown files with rumdl
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.2.40
+    rev: v0.2.57
     hooks:
       - id: rumdl
         args: [--fix]
@@ -104,7 +104,7 @@ repos:
 
   ## Format C++ files with clang-format
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.5
+    rev: v22.1.8
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
@@ -112,7 +112,7 @@ repos:
 
   ## Format and lint Python files with ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.16.3
     hooks:
       - id: ruff-format
         types_or: [python, pyi, jupyter, markdown]
@@ -123,7 +123,7 @@ repos:
 
   ## Check Python types with ty
   - repo: https://github.com/astral-sh/ty-pre-commit
-    rev: v0.0.55
+    rev: v0.0.73
     hooks:
       - id: ty
         args: [--isolated, --only-dev]


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

The pre-commit configuration of the device example had drifted behind the one of the device template. This syncs `examples/device/.pre-commit-config.yaml` with `templates/device/.pre-commit-config.yaml`. The two files are now identical, and their hook revisions match the configuration at the repository root.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://munich-quantum-software-stack.github.io/QDMI/latest/md_docs_2ai__usage.html).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.