### PR TITLE
💥 Remove the calibration advisory property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#unreleased)._
 - 💥 Require generated device projects to use Python 3.11 or newer ([#515])
   ([\@denialhaag])
 
+### Removed
+
+- 💥 Remove the unused calibration advisory device property. Providers can
+  expose proprietary calibration metadata with a custom property ([#512])
+  ([\@burgholzer]).
+
 ## [1.3.3] - 2026-08-19
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#133)._
@@ -229,6 +235,7 @@ for previous changelogs._
 <!-- PR links -->
 
 [#515]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/515
+[#512]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/512
 [#486]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/486
 [#485]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/485
 [#475]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/475

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ cmake_minimum_required(VERSION 3.24...4.4)
 project(
   qdmi
   LANGUAGES C CXX
-  VERSION 1.3.4
+  VERSION 1.4.0
   DESCRIPTION "QDMI –– Quantum Device Management Interface")
 
 set(PROJECT_VERSION_PRERELEASE "-dev")

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,6 +18,15 @@ Generated QDMI device projects now require Python 3.11 or newer and use Python
 3.11 as their stable ABI baseline. Existing generated projects should update
 their Python metadata and wheel configuration when adopting these changes.
 
+### Calibration advisory
+
+The unused `QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION` property is removed.
+Providers can expose proprietary calibration readiness through a custom
+property. `QDMI_DEVICE_STATUS_CALIBRATION` and calibration-job submission remain
+available. Removing the property shifts later regular device-property values
+down by one. Rebuild clients, drivers, and devices against matching QDMI 1.4
+headers; do not mix binaries built against different interim 1.4 revisions.
+
 ## [1.3.3]
 
 ### Retrieving existing jobs by ID

--- a/examples/device/src/cxx_device.cpp
+++ b/examples/device/src/cxx_device.cpp
@@ -802,10 +802,6 @@ int CXX_QDMI_device_session_query_device_property(
   ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_COUPLINGMAP, CXX_QDMI_Site,
                     DEVICE_COUPLING_MAP, prop, size, value, size_ret)
 
-  // The example device never requires calibration
-  ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION, size_t, 0,
-                            prop, size, value, size_ret)
-
   ADD_SINGLE_VALUE_PROPERTY(
       QDMI_DEVICE_PROPERTY_PULSESUPPORT, QDMI_Device_Pulse_Support_Level,
       QDMI_DEVICE_PULSE_SUPPORT_LEVEL_NONE, prop, size, value, size_ret)

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -346,25 +346,13 @@ enum QDMI_DEVICE_PROPERTY_T {
    */
   QDMI_DEVICE_PROPERTY_COUPLINGMAP = 7,
   /**
-   * @brief `size_t` Whether the device needs calibration.
-   * @details This flag indicates whether the device needs calibration.
-   * A value of zero indicates that the device does not need calibration, while
-   * any non-zero value indicates that the device needs calibration. It is up
-   * to the device to assign a specific meaning to the non-zero value.
-   *
-   * If a device reports that it needs calibration, a calibration run can be
-   * triggered by submitting a job with the @ref QDMI_Program_Format set to @ref
-   * QDMI_PROGRAM_FORMAT_CALIBRATION.
-   */
-  QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION = 8,
-  /**
    * @brief @ref QDMI_Device_Pulse_Support_Level Whether the device supports
    * pulse-level control.
    * @details This property indicates the level of pulse-level control.
    * If a device supports pulse-level control, it may provide additional
    * functionality for pulse-level programming and execution.
    */
-  QDMI_DEVICE_PROPERTY_PULSESUPPORT = 9,
+  QDMI_DEVICE_PROPERTY_PULSESUPPORT = 8,
   /**
    * @brief `char*` (string) The length unit reported by the device.
    * @details The device implementation must report a known SI unit (e.g., "mm",
@@ -373,7 +361,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * resulting value is then interpreted in the unit specified by this property.
    * @note If the device reports any length values, this property must be set.
    */
-  QDMI_DEVICE_PROPERTY_LENGTHUNIT = 10,
+  QDMI_DEVICE_PROPERTY_LENGTHUNIT = 9,
   /**
    * @brief `double` A scale factor for all length values.
    * @details The device implementation reports this scale factor. A client must
@@ -383,7 +371,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @note If querying this property returns @ref QDMI_ERROR_NOTSUPPORTED, a
    * client should assume a default value of `1.0`.
    */
-  QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR = 11,
+  QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR = 10,
   /**
    * @brief `char*` (string) The duration unit reported by the device.
    * @details The device implementation must report a known SI unit (e.g., "ms",
@@ -392,7 +380,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * resulting value is then interpreted in the unit specified by this property.
    * @note If the device reports any duration values, this property must be set.
    */
-  QDMI_DEVICE_PROPERTY_DURATIONUNIT = 12,
+  QDMI_DEVICE_PROPERTY_DURATIONUNIT = 11,
   /**
    * @brief `double` A scale factor for all duration values.
    * @details The device implementation reports this scale factor. A client must
@@ -402,7 +390,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @note If querying this property returns @ref QDMI_ERROR_NOTSUPPORTED, a
    * client should assume a default value of `1.0`.
    */
-  QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR = 13,
+  QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR = 12,
   /**
    * @brief `uint64_t` The raw, unscaled minimum required distance between
    * qubits during quantum computation.
@@ -421,7 +409,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @see QDMI_DEVICE_PROPERTY_LENGTHUNIT
    *      QDMI_DEVICE_PROPERTY_LENGTSCALEFACTOR
    */
-  QDMI_DEVICE_PROPERTY_MINATOMDISTANCE = 14,
+  QDMI_DEVICE_PROPERTY_MINATOMDISTANCE = 13,
   /**
    * @brief `QDMI_Program_Format*` (@ref QDMI_Program_Format list) The program
    * formats supported by the device.
@@ -429,7 +417,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * supports for execution. A client can use this information to determine
    * which program formats can be used when submitting jobs to the device.
    */
-  QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS = 15,
+  QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS = 14,
   /**
    * @brief `QDMI_Child_Device*` (@ref QDMI_Child_Device list) A list of device
    * handles corresponding to the device's child devices managed by this device.
@@ -443,7 +431,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @note Devices with child devices may have special job submission handling.
    * Check the concrete device's job interface documentation.
    */
-  QDMI_DEVICE_PROPERTY_CHILDDEVICES = 16,
+  QDMI_DEVICE_PROPERTY_CHILDDEVICES = 15,
   /**
    * @brief `size_t` The current number of jobs waiting to access the device.
    * @details This property is a snapshot of the device's queue length and does
@@ -458,7 +446,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * The property may yield @ref QDMI_ERROR_NOTSUPPORTED if the implementation
    * cannot obtain a trustworthy queue length.
    */
-  QDMI_DEVICE_PROPERTY_QUEUELENGTH = 17,
+  QDMI_DEVICE_PROPERTY_QUEUELENGTH = 16,
   /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
@@ -467,7 +455,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @attention This value must remain the last regular member of the enum
    * besides the custom members and must be updated when new members are added.
    */
-  QDMI_DEVICE_PROPERTY_MAX = 18,
+  QDMI_DEVICE_PROPERTY_MAX = 17,
   /**
    * @brief This enum value is reserved for a custom property.
    * @details The device defines the meaning and the type of this property.

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -1155,15 +1155,6 @@ TEST_P(QDMIImplementationTest, SupportsCalibration) {
   EXPECT_EQ(QDMI_job_submit(job), QDMI_SUCCESS);
 }
 
-TEST_P(QDMIImplementationTest, NeedsCalibration) {
-  size_t needs_calibration = 0;
-  const auto ret = QDMI_device_query_device_property(
-      device, QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION, sizeof(size_t),
-      &needs_calibration, nullptr);
-  EXPECT_EQ(ret, QDMI_SUCCESS);
-  EXPECT_EQ(needs_calibration, 0);
-}
-
 TEST_P(QDMIImplementationTest, QueryPulseSupportLevel) {
   QDMI_Device_Pulse_Support_Level pulse_support_level =
       QDMI_DEVICE_PULSE_SUPPORT_LEVEL_NONE;


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Remove the unused `QDMI_DEVICE_PROPERTY_NEEDSCALIBRATION` advisory and close the regular property-enum gap. Preserve `QDMI_DEVICE_STATUS_CALIBRATION` and calibration-job submission. Provider-specific calibration readiness can use a custom property.

This is the first independent metadata-cleanup layer, based directly on `v1.4`; #513 follows it. It does not include payload capabilities, multi-program jobs, or replaceable drivers. The breaking development headers are identified as 1.4.0-dev.

## Validation

- Release configure/build: passed, including example and template targets.
- CTest: 83 passed; 18 expected read-only job tests skipped; no failures.
- `uvx prek run -a`: passed.
- Rebased commit signed and verified. Fresh hosted CI is pending; earlier-stack results are not evidence for this head.

AI assistance: Codex separated the stack, adapted the cleanup to develop, and ran local validation.

## Consumer compatibility

Removing the advisory does not remove calibration-job submission or the CALIBRATION status. Keep provider-specific calibration readiness and workflows in documented extensions; no common calibration workflow is standardized here.

Before the interface change merges, link a working Core consumer and a demonstration with at least one existing provider, preferably both where applicable. Compatibility evidence suffices when a provider needs no changes. Development revisions may support these tests; published artifacts must use released dependencies. Core adoption: [#2233](https://github.com/munich-quantum-toolkit/core/pull/2233).

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://munich-quantum-software-stack.github.io/QDMI/latest/md_docs_2ai__usage.html).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
