### PR TITLE
💥 Remove unused pulse metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#unreleased)._
 
 ### Removed
 
+- 💥 Remove the unused pulse-support device property and level type. Providers
+  can expose pulse programming through a separate vendor interface ([#513])
+  ([\@burgholzer]).
 - 💥 Remove the unused calibration advisory device property. Providers can
   expose proprietary calibration metadata with a custom property ([#512])
   ([\@burgholzer]).
@@ -235,6 +238,7 @@ for previous changelogs._
 <!-- PR links -->
 
 [#515]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/515
+[#513]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/513
 [#512]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/512
 [#486]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/486
 [#485]: https://github.com/Munich-Quantum-Software-Stack/QDMI/pull/485

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -27,6 +27,15 @@ available. Removing the property shifts later regular device-property values
 down by one. Rebuild clients, drivers, and devices against matching QDMI 1.4
 headers; do not mix binaries built against different interim 1.4 revisions.
 
+### Pulse metadata
+
+The unused `QDMI_DEVICE_PROPERTY_PULSESUPPORT` property and
+`QDMI_Device_Pulse_Support_Level` type are removed. QDMI does not define a
+pulse-programming interface. Providers can expose pulse programming through
+custom program formats or a separate vendor interface. The removal shifts later
+regular device-property values down by one again; rebuild all clients, drivers,
+and devices against matching headers.
+
 ## [1.3.3]
 
 ### Retrieving existing jobs by ID

--- a/examples/device/src/cxx_device.cpp
+++ b/examples/device/src/cxx_device.cpp
@@ -802,10 +802,6 @@ int CXX_QDMI_device_session_query_device_property(
   ADD_LIST_PROPERTY(QDMI_DEVICE_PROPERTY_COUPLINGMAP, CXX_QDMI_Site,
                     DEVICE_COUPLING_MAP, prop, size, value, size_ret)
 
-  ADD_SINGLE_VALUE_PROPERTY(
-      QDMI_DEVICE_PROPERTY_PULSESUPPORT, QDMI_Device_Pulse_Support_Level,
-      QDMI_DEVICE_PULSE_SUPPORT_LEVEL_NONE, prop, size, value, size_ret)
-
   ADD_STRING_PROPERTY(QDMI_DEVICE_PROPERTY_LENGTHUNIT, "um", prop, size, value,
                       size_ret)
   ADD_SINGLE_VALUE_PROPERTY(QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR, double, 1.0,

--- a/include/qdmi/constants.h
+++ b/include/qdmi/constants.h
@@ -346,14 +346,6 @@ enum QDMI_DEVICE_PROPERTY_T {
    */
   QDMI_DEVICE_PROPERTY_COUPLINGMAP = 7,
   /**
-   * @brief @ref QDMI_Device_Pulse_Support_Level Whether the device supports
-   * pulse-level control.
-   * @details This property indicates the level of pulse-level control.
-   * If a device supports pulse-level control, it may provide additional
-   * functionality for pulse-level programming and execution.
-   */
-  QDMI_DEVICE_PROPERTY_PULSESUPPORT = 8,
-  /**
    * @brief `char*` (string) The length unit reported by the device.
    * @details The device implementation must report a known SI unit (e.g., "mm",
    * "um", or "nm") for this property. A client querying a length value must
@@ -361,7 +353,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * resulting value is then interpreted in the unit specified by this property.
    * @note If the device reports any length values, this property must be set.
    */
-  QDMI_DEVICE_PROPERTY_LENGTHUNIT = 9,
+  QDMI_DEVICE_PROPERTY_LENGTHUNIT = 8,
   /**
    * @brief `double` A scale factor for all length values.
    * @details The device implementation reports this scale factor. A client must
@@ -371,7 +363,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @note If querying this property returns @ref QDMI_ERROR_NOTSUPPORTED, a
    * client should assume a default value of `1.0`.
    */
-  QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR = 10,
+  QDMI_DEVICE_PROPERTY_LENGTHSCALEFACTOR = 9,
   /**
    * @brief `char*` (string) The duration unit reported by the device.
    * @details The device implementation must report a known SI unit (e.g., "ms",
@@ -380,7 +372,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * resulting value is then interpreted in the unit specified by this property.
    * @note If the device reports any duration values, this property must be set.
    */
-  QDMI_DEVICE_PROPERTY_DURATIONUNIT = 11,
+  QDMI_DEVICE_PROPERTY_DURATIONUNIT = 10,
   /**
    * @brief `double` A scale factor for all duration values.
    * @details The device implementation reports this scale factor. A client must
@@ -390,7 +382,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @note If querying this property returns @ref QDMI_ERROR_NOTSUPPORTED, a
    * client should assume a default value of `1.0`.
    */
-  QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR = 12,
+  QDMI_DEVICE_PROPERTY_DURATIONSCALEFACTOR = 11,
   /**
    * @brief `uint64_t` The raw, unscaled minimum required distance between
    * qubits during quantum computation.
@@ -409,7 +401,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @see QDMI_DEVICE_PROPERTY_LENGTHUNIT
    *      QDMI_DEVICE_PROPERTY_LENGTSCALEFACTOR
    */
-  QDMI_DEVICE_PROPERTY_MINATOMDISTANCE = 13,
+  QDMI_DEVICE_PROPERTY_MINATOMDISTANCE = 12,
   /**
    * @brief `QDMI_Program_Format*` (@ref QDMI_Program_Format list) The program
    * formats supported by the device.
@@ -417,7 +409,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * supports for execution. A client can use this information to determine
    * which program formats can be used when submitting jobs to the device.
    */
-  QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS = 14,
+  QDMI_DEVICE_PROPERTY_SUPPORTEDPROGRAMFORMATS = 13,
   /**
    * @brief `QDMI_Child_Device*` (@ref QDMI_Child_Device list) A list of device
    * handles corresponding to the device's child devices managed by this device.
@@ -431,7 +423,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @note Devices with child devices may have special job submission handling.
    * Check the concrete device's job interface documentation.
    */
-  QDMI_DEVICE_PROPERTY_CHILDDEVICES = 15,
+  QDMI_DEVICE_PROPERTY_CHILDDEVICES = 14,
   /**
    * @brief `size_t` The current number of jobs waiting to access the device.
    * @details This property is a snapshot of the device's queue length and does
@@ -446,7 +438,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * The property may yield @ref QDMI_ERROR_NOTSUPPORTED if the implementation
    * cannot obtain a trustworthy queue length.
    */
-  QDMI_DEVICE_PROPERTY_QUEUELENGTH = 16,
+  QDMI_DEVICE_PROPERTY_QUEUELENGTH = 15,
   /**
    * @brief The maximum value of the enum.
    * @details It can be used by devices for bounds checking and validation of
@@ -455,7 +447,7 @@ enum QDMI_DEVICE_PROPERTY_T {
    * @attention This value must remain the last regular member of the enum
    * besides the custom members and must be updated when new members are added.
    */
-  QDMI_DEVICE_PROPERTY_MAX = 17,
+  QDMI_DEVICE_PROPERTY_MAX = 16,
   /**
    * @brief This enum value is reserved for a custom property.
    * @details The device defines the meaning and the type of this property.
@@ -783,7 +775,7 @@ enum QDMI_OPERATION_PROPERTY_T {
    * occur, resulting in lower fidelity compared to qubits that are simply
    * idling and not exposed to the operation.
    * @note This is especially relevant for neutral atom devices, where global
-   * operations (e.g., laser pulses) can impact all atoms in the array,
+   * laser operations can impact all atoms in the array,
    * including those not interacting.
    */
   QDMI_OPERATION_PROPERTY_IDLINGFIDELITY = 7,
@@ -1182,45 +1174,6 @@ enum QDMI_JOB_RESULT_T {
 
 /// Job result type.
 typedef enum QDMI_JOB_RESULT_T QDMI_Job_Result;
-
-/**
- * @brief Enum to indicate the level of pulse support a device has.
- */
-enum QDMI_DEVICE_PULSE_SUPPORT_LEVEL_T {
-  /// The device does not support pulse-level control.
-  QDMI_DEVICE_PULSE_SUPPORT_LEVEL_NONE = 0,
-  /**
-   * @brief The device supports pulse-level control at an abstraction level of
-   * @ref QDMI_Site.
-   * @details This means that the device can execute pulse-level
-   * instructions on the sites of the device.
-   * This level of support is sufficient for most devices that can execute
-   * quantum circuits with pulse-level control, as it allows the device to
-   * execute pulse-level instructions on the sites of the device.
-   * @see QDMI_Site for more information on the site abstraction.
-   */
-  QDMI_DEVICE_PULSE_SUPPORT_LEVEL_SITE = 1,
-  /**
-   * @brief The device supports pulse-level control at an abstraction level of
-   * `QDMI_Pulse_Channel`.
-   * @details This means that the device can execute pulse-level instructions on
-   * the channels of the device.
-   * This level of support is sufficient for devices that can execute quantum
-   * circuits with pulse-level control on a channel basis, such as devices that
-   * use a single channel for all sites.
-   */
-  QDMI_DEVICE_PULSE_SUPPORT_LEVEL_CHANNEL = 2,
-  /**
-   * @brief The device supports pulse-level control at an abstraction level of
-   * @ref QDMI_Site and `QDMI_Pulse_Channel`.
-   * @details This means that the device can execute pulse-level instructions on
-   * both the sites and channels of the device.
-   */
-  QDMI_DEVICE_PULSE_SUPPORT_LEVEL_SITEANDCHANNEL = 3,
-};
-
-/// Pulse support level type.
-typedef enum QDMI_DEVICE_PULSE_SUPPORT_LEVEL_T QDMI_Device_Pulse_Support_Level;
 
 // NOLINTEND(performance-enum-size, modernize-use-using)
 

--- a/include/qdmi/types.h
+++ b/include/qdmi/types.h
@@ -58,7 +58,7 @@ typedef struct QDMI_Site_impl_d *QDMI_Site;
  * @details An opaque pointer to an implementation of the QDMI operation
  * concept. An operation generally represents any instruction that can be
  * executed on a device. This includes gates, measurements, classical control
- * flow elements, movement of qubits, pulse-level instructions, etc.
+ * flow elements, and movement of qubits.
  * Each implementation of the @ref device_interface "QDMI Device Interface"
  * defines the actual implementation of the concept.
  *

--- a/test/test_qdmi.cpp
+++ b/test/test_qdmi.cpp
@@ -1155,16 +1155,6 @@ TEST_P(QDMIImplementationTest, SupportsCalibration) {
   EXPECT_EQ(QDMI_job_submit(job), QDMI_SUCCESS);
 }
 
-TEST_P(QDMIImplementationTest, QueryPulseSupportLevel) {
-  QDMI_Device_Pulse_Support_Level pulse_support_level =
-      QDMI_DEVICE_PULSE_SUPPORT_LEVEL_NONE;
-  const auto ret = QDMI_device_query_device_property(
-      device, QDMI_DEVICE_PROPERTY_PULSESUPPORT,
-      sizeof(QDMI_Device_Pulse_Support_Level), &pulse_support_level, nullptr);
-  EXPECT_EQ(ret, QDMI_SUCCESS);
-  EXPECT_EQ(pulse_support_level, QDMI_DEVICE_PULSE_SUPPORT_LEVEL_NONE);
-}
-
 // Standalone tests for driver library loading corner cases
 TEST(QDMIDriverLoadingTest, LoadConfigWithNonExistentFile) {
   // Save the original QDMI_CONF environment variable


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Remove `QDMI_DEVICE_PROPERTY_PULSESUPPORT` and `QDMI_Device_Pulse_Support_Level`, which have no corresponding pulse-programming interface. Keep provider-specific pulse programs possible without prescribing their design; requirements are tracked in #523.

This is the second metadata-cleanup layer: `v1.4` → #512 → #513. No dependency on payload capabilities, multi-program jobs, or replaceable drivers remains. The regular property-enum gap is closed; consumers must rebuild against matching 1.4 headers.

## Validation

- Release build: passed, including example and template targets.
- CTest: 81 passed; 18 expected read-only job tests skipped; no failures.
- `uvx prek run -a`: passed.
- Commit signed and verified. Fresh hosted CI is pending.

AI assistance: Codex separated the stack, preserved current develop tests, and ran local validation.

## Pulse submission boundary

Removing the coarse pulse metadata does not remove provider-defined pulse-program submission. Opaque payload transport, compiler-construction metadata, and a standardized pulse programming interface are separate concerns. Keep [IQM #200](https://github.com/iqm-finland/QDMI-on-IQM/pull/200) and [#234](https://github.com/iqm-finland/QDMI-on-IQM/issues/234) linked to #171/#523 without making transport wait for a universal pulse interface.

Before the interface change merges, link a working Core consumer and a demonstration with at least one existing provider, preferably both where applicable. Compatibility evidence suffices when a provider needs no changes. Development revisions may support these tests; published artifacts must use released dependencies. Core adoption: [#2233](https://github.com/munich-quantum-toolkit/core/pull/2233).

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] I have disclosed the use of AI tools in the PR description as per our [AI Usage Guidelines](https://munich-quantum-software-stack.github.io/QDMI/latest/md_docs_2ai__usage.html).
- [x] AI-assisted commits include an `Assisted-by: [Model Name] via [Tool Name]` footer.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
